### PR TITLE
Added convenience methods for adding / removing custom encoders.

### DIFF
--- a/src/cheshire/custom.clj
+++ b/src/cheshire/custom.clj
@@ -63,14 +63,14 @@
 (def generate-stream encode-stream)
 (def generate-smile encode-smile)
 
-(defn- encode-nil [_ ^JsonGenerator jg]
+(defn encode-nil [_ ^JsonGenerator jg]
   (.writeNull jg))
 
 (extend nil
   Jable
   {:to-json encode-nil})
 
-(defn- encode-str [^String s ^JsonGenerator jg]
+(defn encode-str [^String s ^JsonGenerator jg]
   (.writeString jg (str s)))
 
 (extend java.lang.String
@@ -150,3 +150,25 @@
 (extend clojure.lang.Symbol
   Jable
   {:to-json encode-symbol})
+
+
+(defn add-encoder
+  "Provide an encoder for a type not handled by Cheshire.
+
+   ex. (add-encoder java.net.URL encode-string)
+
+   See encode-str, encode-map, etc, in the cheshire.custom
+   namespace for encoder examples."
+  [^java.util.Class cls encoder]
+  (extend cls
+    Jable
+    {:to-json encoder}))
+
+(defn remove-encoder [cls]
+  "Remove encoder for a given type.
+
+   ex. (remove-encoder java.net.URL)"
+  (alter-var-root
+   #'Jable
+   #(assoc % :impls (dissoc (:impls %) cls)))
+  (clojure.core/-reset-methods Jable))

--- a/test/cheshire/test/custom.clj
+++ b/test/cheshire/test/custom.clj
@@ -1,7 +1,7 @@
 (ns cheshire.test.custom
   (:use [clojure.test]
         [clojure.java.io :only [reader]])
-  (:require [cheshire.custom :as json])
+  (:require [cheshire.custom :as json] :reload)
   (:import (java.io StringReader StringWriter
                     BufferedReader BufferedWriter)
            (java.util Date UUID)))
@@ -111,3 +111,15 @@
       (prn min-time max-time)
       (is (> 2000 min-time))
       (is (> 5200 max-time)))))
+
+
+(deftest test-add-remove-encoder
+  (do
+    (json/remove-encoder java.net.URL)
+    (json/add-encoder java.net.URL json/encode-str)
+    (is (= "\"http://foo.com\""
+           (json/generate-string (java.net.URL. "http://foo.com")))))
+  (do
+    (json/remove-encoder java.net.URL)
+    (is (thrown? IllegalArgumentException
+                 (json/generate-string (java.net.URL. "http://foo.com"))))))


### PR DESCRIPTION
Pretty straightforward.  Also changed encode-nil and encode-str to public so that clients can use these pre-made encoders.
