### PR TITLE
Added guard against NPE for cheshire.core/parse-string

### DIFF
--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -49,9 +49,10 @@
   keywords? should be true if keyword keys are needed, the default is false
   maps will use strings as keywords."
   [^String string & [^Boolean keywords?]]
-  (parse
-   (.createJsonParser factory (StringReader. string))
-   true (or keywords? false) nil))
+  (when string
+    (parse
+     (.createJsonParser factory (StringReader. string))
+     true (or keywords? false) nil)))
 
 (defn parse-stream
   "Returns the Clojure object corresponding to the given reader, reader must

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -51,6 +51,9 @@
          (json/parse-string
           (json/generate-string {"foo" 'clojure.core/map})))))
 
+(deftest test-nil
+  (is (nil? (json/parse-string nil true))))
+
 (deftest test-parsed-seq
   (let [br (BufferedReader. (StringReader. "1\n2\n3\n"))]
     (is (= (list 1 2 3) (json/parsed-seq br)))))


### PR DESCRIPTION
Can't think of a good reason off the top of my head for the NPE, but disregard if this is by design.  

If the change looks good you might want to think about guarding parse-stream and parse-smile as well.
