### PR TITLE
Added boolean option for parsing json arrays as clojure sets and support for clojure Ratio type

### DIFF
--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -134,3 +134,7 @@
 (deftest test-namespaced-keywords
   (is (= "{\"foo\":\"user/bar\"}"
          (json/encode {:foo :user/bar}))))
+
+(deftest test-array-coerce-fn
+  (is (= {"set" #{"a" "b"} "array" ["a" "b"]}
+         (json/parse-string (json/generate-string {"set" #{"a" "b"} "array" ["a" "b"]}) false (fn [field-name] (if (= "set" field-name) #{} []))))))


### PR DESCRIPTION
I often serialize clojure sets into json structures, and I'd find it very useful to have them parsed back as sets rather than arrays.
So I've added a boolean option to all parse functions (sets?, false by default), for parsing all json arrays as clojure sets: I've also added a test case, and everything seems to work fine.

Also, I've added support for Clojure Ratio type.

Hope you find it useful!  
