### PR TITLE
BigDecimal support

### DIFF
--- a/src/cheshire/generate.clj
+++ b/src/cheshire/generate.clj
@@ -22,6 +22,7 @@
          Double (.writeNumber ~jg (double ~obj))
          Float (.writeNumber ~jg (double ~obj))
          BigInteger (.writeNumber ~jg ^BigInteger ~obj)
+         BigDecimal (.writeNumber ~jg ^BigDecimal ~obj)
          clojure.lang.BigInt (.writeNumber ~jg (.toBigInteger (bigint ~obj)))
          (fail ~obj)))
     (do
@@ -31,6 +32,7 @@
          Double (.writeNumber ~jg (double ~obj))
          Float (.writeNumber ~jg (float ~obj))
          BigInteger (.writeNumber ~jg ^BigInteger ~obj)
+         BigDecimal (.writeNumber ~jg ^BigDecimal ~obj)
          (fail ~obj)))))
 
 (defn generate [^JsonGenerator jg obj ^String date-format]

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -20,6 +20,10 @@
   (let [n (BigInteger. "42")]
     (is (= n (:num (json/decode (json/encode {:num n}) true))))))
 
+(deftest t-bigdecimal
+  (let [n (BigDecimal. "42.5")]
+    (is (= (.doubleValue n) (:num (json/decode (json/encode {:num n}) true))))))
+
 (deftest test-string-round-trip
   (is (= test-obj (json/parse-string (json/generate-string test-obj)))))
 


### PR DESCRIPTION
BigDecimals are directly supported by the JsonGenerator, so trivial to
add support from cheshire.
