### PR TITLE
datomic.query.EntityMap support

### DIFF
--- a/src/cheshire/generate.clj
+++ b/src/cheshire/generate.clj
@@ -75,7 +75,9 @@
                             clojure.lang.IPersistentList
                             (generate-array jg obj date-format ex)
                             clojure.lang.ISeq
-                            (generate-array jg obj date-format ex))
+                            (generate-array jg obj date-format ex)
+                            clojure.lang.Associative
+                            (generate-map jg obj date-format ex))
     Map (generate-map jg obj date-format ex)
     List (generate-array jg obj date-format ex)
     Set (generate jg (seq obj) date-format ex)


### PR DESCRIPTION
datomic.query.EntityMap implements the interfaces:

  interface clojure.lang.IPersistentCollection
  interface datomic.query.EMapImpl
  interface clojure.lang.Associative
  interface clojure.lang.Seqable
  interface clojure.lang.ILookup
  interface datomic.Entity
  interface clojure.lang.IType

so added a clojure.lang.Associative clause in the IPersistentCollection route to generate a json-map.
