### PR TITLE
Empty sets are serialized to empty arrays instead of null

### DIFF
--- a/src/cheshire/generate.clj
+++ b/src/cheshire/generate.clj
@@ -71,7 +71,7 @@
                             clojure.lang.IPersistentVector
                             (generate-array jg obj date-format ex)
                             clojure.lang.IPersistentSet
-                            (generate jg (seq obj) date-format ex)
+                            (generate-array jg obj date-format ex)
                             clojure.lang.IPersistentList
                             (generate-array jg obj date-format ex)
                             clojure.lang.ISeq
@@ -80,7 +80,7 @@
                             (generate-map jg obj date-format ex))
     Map (generate-map jg obj date-format ex)
     List (generate-array jg obj date-format ex)
-    Set (generate jg (seq obj) date-format ex)
+    Set (generate-array jg obj date-format ex)
     Number (number-dispatch ^JsonGenerator jg obj ex)
     String (write-string ^JsonGenerator jg ^String obj )
     Keyword (write-string ^JsonGenerator jg

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -49,6 +49,18 @@
   (is (= {"set" ["a" "b"]}
          (json/decode (json/encode {"set" #{"a" "b"}})))))
 
+(deftest test-generate-empty-set
+  (is (= {"set" ["a" "b"]}
+         (json/decode (json/encode {"set" #{}})))))
+
+(deftest test-generate-empty-set
+  (is (= {"set" []}
+         (json/decode (json/encode {"set" #{}})))))
+
+(deftest test-generate-empty-array
+  (is (= {"array" []}
+         (json/decode (json/encode {"array" []})))))
+
 (deftest test-key-coercion
   (is (= {"foo" "bar" "1" "bat" "2" "bang" "3" "biz"}
          (json/decode
@@ -81,6 +93,10 @@
                                             (.add 1)
                                             (.add 2)
                                             (.add 3))})))))
+
+(deftest test-accepts-empty-java-set
+  (is (= {"set" []}
+         (json/decode (json/encode {"set" (doto (java.util.HashSet. 3))})))))
 
 (deftest test-nil
   (is (nil? (json/decode nil true))))


### PR DESCRIPTION
Right now empty vectors/arrays are serialized to "[]" but empty sets are serialized to "null". This patch makes empty sets to be serialized to "[]", so they are consistent with the empty vectors.
