### PR TITLE
get rid of some of the type hint warnings

### DIFF
--- a/src/cheshire/generate.clj
+++ b/src/cheshire/generate.clj
@@ -31,25 +31,26 @@
        Long (.writeNumber ~jg (long ~obj))
        Double (.writeNumber ~jg (double ~obj))
        Float (.writeNumber ~jg (double ~obj))
-       BigInteger (.writeNumber ~jg ^BigInteger ~obj)
-       BigDecimal (.writeNumber ~jg ^BigDecimal ~obj)
+       BigInteger (.writeNumber ~jg ~(with-meta obj {:tag "BigInteger"}))
+       BigDecimal (.writeNumber ~jg ~(with-meta obj {:tag "BigDecimal"}))
        Ratio (.writeNumber ~jg (double ~obj))
        Short (.writeNumber ~jg (int ~obj))
        Byte (.writeNumber ~jg (int ~obj))
-       clojure.lang.BigInt (.writeNumber ~jg ^clojure.lang.BigInt
-                                         (.toBigInteger (bigint ~obj)))
+       clojure.lang.BigInt (.writeNumber ~jg ^BigInteger
+                             (.toBigInteger ^clojure.lang.BigInt (bigint ~obj)))
        (fail ~obj ~jg ~e))
-    `(condp instance? ~obj
-       Integer (.writeNumber ~jg (int ~obj))
-       Long (.writeNumber ~jg (long ~obj))
-       Double (.writeNumber ~jg (double ~obj))
-       Float (.writeNumber ~jg (float ~obj))
-       BigInteger (.writeNumber ~jg ^BigInteger ~obj)
-       BigDecimal (.writeNumber ~jg ^BigDecimal ~obj)
-       Ratio (.writeNumber ~jg (double ~obj))
-       Short (.writeNumber ~jg (int ~obj))
-       Byte (.writeNumber ~jg (int ~obj))
-       (fail ~obj ~jg ~e))))
+    `(let [^JsonGenerator jg# ~jg]
+       (condp instance? ~obj
+         Integer (.writeNumber jg# (int ~obj))
+         Long (.writeNumber jg# (long ~obj))
+         Double (.writeNumber jg# (double ~obj))
+         Float (.writeNumber jg# (float ~obj))
+         BigInteger (.writeNumber jg# ^BigInteger ~obj)
+         BigDecimal (.writeNumber jg# ^BigDecimal ~obj)
+         Ratio (.writeNumber jg# (double ~obj))
+         Short (.writeNumber jg# (int ~obj))
+         Byte (.writeNumber jg# (int ~obj))
+         (fail ~obj jg# ~e)))))
 
 (declare generate)
 
@@ -117,7 +118,8 @@
                         (write-string ^JsonGenerator jg (.format sdf obj)))
    :else (try
            (.writeNumber ^JsonGenerator jg obj)
-           (catch Exception e (fail obj jg ex)))))
+           (catch Exception e
+             (fail obj jg ex)))))
 
 ;; Generic encoders, these can be used by someone writing a custom
 ;; encoder if so desired, after transforming an arbitrary data


### PR DESCRIPTION
I was wondering why my projects with `:warn-on-reflection` enabled complained so much about Cheshire.  On investigation, it appears that some of this is intentional (sometimes we don't know what it is), but there were a few cases that weren't being properly type-hinted when they could be.

Let me know if I've misunderstood the intent anywhere, and made things worse.
