### PR TITLE
Replace doseq in generate/encode-map with loop and recur to reduce initial memory footprint.

### DIFF
--- a/src/cheshire/generate.clj
+++ b/src/cheshire/generate.clj
@@ -210,13 +210,17 @@
   "Encode a clojure map to the json generator."
   [^clojure.lang.IPersistentMap m ^JsonGenerator jg]
   (.writeStartObject jg)
-  (doseq [[k v] m]
-    (.writeFieldName jg (if (instance? clojure.lang.Keyword k)
-                          (if-let [ns (namespace k)]
-                            (str ns "/" (name k))
-                            (name k))
-                          (str k)))
-    (generate jg v *date-format* nil nil))
+  (loop [im (seq m)]
+    (let [[k v] (first im)
+          rm (rest im)]
+      (.writeFieldName jg (if (instance? clojure.lang.Keyword k)
+                            (if-let [ns (namespace k)]
+                              (str ns "/" (name k))
+                              (name k))
+                            (str k)))
+      (generate jg v *date-format* nil nil)
+      (when (seq rm)
+        (recur rm))))
   (.writeEndObject jg))
 
 (defn encode-symbol


### PR DESCRIPTION
With testing on my local system this change reduced the memory footprint by ~10mb.
Because doseq uses loop/recur internally, and this fn isn't using any of its special features, it seemed like an easy and safe replacement.
