### PR TITLE
Fixed 1- and 2-argument forms of parse-string-strict.

### DIFF
--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -104,8 +104,8 @@
   and returning the collection to be used for array values.
 
   Does not lazily parse top-level arrays."
-  ([string] (parse-string string nil nil))
-  ([string key-fn] (parse-string string key-fn nil))
+  ([string] (parse-string-strict string nil nil))
+  ([string key-fn] (parse-string-strict string key-fn nil))
   ([^String string key-fn array-coerce-fn]
      (when string
        (parse/parse-strict


### PR DESCRIPTION
When called with only 1 or 2 arguments, parse-string-strict deferred its
work to the 4-argument form of parse-string instead of
parse-string-strict (thus still decoding top-level arrays as lazy seqs
instead of vectors).

Finishes fixing #46 and #48.
