### PR TITLE
Fixed README examples with Date class

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ encoders.
 ;; generate some JSON with Dates
 ;; the Date will be encoded as a string using
 ;; the default date format: yyyy-MM-dd'T'HH:mm:ss'Z'
-(generate-string {:foo "bar" :baz (Date. 0)})
+(generate-string {:foo "bar" :baz (java.util.Date. 0)})
 
 ;; generate some JSON with Dates with custom Date encoding
-(generate-string {:baz (Date. 0)} {:date-format "yyyy-MM-dd"})
+(generate-string {:baz (java.util.Date. 0)} {:date-format "yyyy-MM-dd"})
 
 ;; generate some JSON with pretty formatting
 (generate-string {:foo "bar" :baz {:eggplant [1 2 3]}} {:pretty true})


### PR DESCRIPTION
Running the examples with `Date` class from the README generate the following exceptions:

> CompilerException java.lang.IllegalArgumentException: Unable to resolve classname: Date, compiling:(NO_SOURCE_PATH:1:24) 

This PR fixes this issue by specifying `java.util.Date` instead of `Date` in the examples.
