### PR TITLE
Add doc strings for clojure-json aliases

### DIFF
--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -267,10 +267,10 @@
                     key-fn array-coerce-fn))))
 
 ;; aliases for clojure-json users
-(def encode generate-string)
-(def encode-stream generate-stream)
-(def encode-smile generate-smile)
-(def decode parse-string)
-(def decode-strict parse-string-strict)
-(def decode-stream parse-stream)
-(def decode-smile parse-smile)
+(def encode "Alias to generate-string for clojure-json users" generate-string)
+(def encode-stream "Alias to generate-stream for clojure-json users" generate-stream)
+(def encode-smile "Alias to generate-smile for clojure-json users" generate-smile)
+(def decode "Alias to parse-string for clojure-json users" parse-string)
+(def decode-strict "Alias to parse-string-strict for clojure-json users" parse-string-strict)
+(def decode-stream "Alias to parse-stream for clojure-json users" parse-stream)
+(def decode-smile "Alias to parse-smile for clojure-json users" parse-smile)


### PR DESCRIPTION
I was using cheshire from the REPL and got confused when I saw decode-stream and parse-stream as functions available. I went to get the docs on decode-stream and there was nothing there which confused me further. Looking at the source cleared it up and showed me that decode-stream was an alias to parse-stream for clojure-json users. I thought it could be helpful for other people if there were doc strings on the clojure-json aliases.
