### PR TITLE
disable tiered compilation for benchmark runs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,6 +17,7 @@
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha4"]]}
              :benchmark {:test-paths ["benchmarks"]
+                         :jvm-opts ^:replace ["-Xms1g" "-Xmx1g" "-server"]
                          :dependencies [[criterium "0.4.3"]
                                         [org.clojure/data.json "0.2.5"]
                                         [clj-json "0.5.3"]]}}


### PR DESCRIPTION
by default, leiningen sets the JVM up for startup time, via tiered
compilation (see https://github.com/technomancy/leiningen/wiki/Faster).

This doesn't play so well with benchmarks, so when running benchmarks, you
need to turn off tiered compilation. Also nearly every production
jvm runs with AggressiveOpts, UseFastAccessorMethods, and -server, so
enable them too.

comparison output (note: not too meaningful, given that most folk running
cheshire in production won't be using it on a laptop running os x, but
it gives some idea of the difference):

https://gist.github.com/tcrayford/1744556933d71f120605