### PR TITLE
Refactor internal functions to use opts map

### DIFF
--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -11,6 +11,9 @@
            (java.io StringWriter StringReader BufferedReader BufferedWriter
                     ByteArrayOutputStream OutputStream Reader Writer)))
 
+(def default-opts
+  {:date-format factory/default-date-format})
+
 ;; Generators
 (defn ^String generate-string
   "Returns a JSON-encoding String for the given Clojure object. Takes an
@@ -29,10 +32,7 @@
        (.useDefaultPrettyPrinter generator))
      (when (:escape-non-ascii opt-map)
        (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
-     (gen/generate generator obj
-                   (or (:date-format opt-map) factory/default-date-format)
-                   (:ex opt-map)
-                   (:key-fn opt-map))
+     (gen/generate generator obj (merge default-opts opt-map))
      (.flush generator)
      (.toString sw))))
 
@@ -53,10 +53,7 @@
        (.useDefaultPrettyPrinter generator))
      (when (:escape-non-ascii opt-map)
        (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
-     (gen/generate generator obj (or (:date-format opt-map)
-                                     factory/default-date-format)
-                   (:ex opt-map)
-                   (:key-fn opt-map))
+     (gen/generate generator obj (merge default-opts opt-map))
      (.flush generator)
      writer)))
 
@@ -92,11 +89,8 @@
   - :end - write object with end border only."
   ([obj] (write obj nil))
   ([obj wholeness]
-   (gen-seq/generate *generator* obj (or (:date-format *opt-map*)
-                                         factory/default-date-format)
-                     (:ex *opt-map*)
-                     (:key-fn *opt-map*)
-                     :wholeness wholeness)))
+   (gen-seq/generate *generator* obj (assoc (merge default-opts *opt-map*)
+                                            :wholeness wholeness))))
 
 (defn generate-smile
   "Returns a SMILE-encoded byte-array for the given Clojure object.
@@ -111,10 +105,7 @@
                                      (or factory/*smile-factory*
                                          factory/smile-factory)
                                      ^OutputStream baos)]
-     (gen/generate generator obj (or (:date-format opt-map)
-                                     factory/default-date-format)
-                   (:ex opt-map)
-                   (:key-fn opt-map))
+     (gen/generate generator obj (merge default-opts opt-map))
      (.flush generator)
      (.toByteArray baos))))
 
@@ -131,10 +122,7 @@
                                      (or factory/*cbor-factory*
                                          factory/cbor-factory)
                                      ^OutputStream baos)]
-     (gen/generate generator obj (or (:date-format opt-map)
-                                     factory/default-date-format)
-                   (:ex opt-map)
-                   (:key-fn opt-map))
+     (gen/generate generator obj (merge default-opts opt-map))
      (.flush generator)
      (.toByteArray baos))))
 

--- a/src/cheshire/generate_seq.clj
+++ b/src/cheshire/generate_seq.clj
@@ -30,100 +30,103 @@
 (declare generate)
 
 (definline generate-basic-map
-  [^JsonGenerator jg obj ^String date-format ^Exception e
-   wholeness]
+  [^JsonGenerator jg obj opts]
   (let [jg (tag jg)]
-    `(do
-       (write-start-object ~jg ~wholeness)
+    `(let [wholeness# (:wholeness ~opts)
+           inner-opts# (assoc ~opts :wholeness
+                              (if (= wholeness# :start-inner)
+                                :start
+                                :all))]
+       (write-start-object ~jg wholeness#)
        (doseq [m# ~obj]
          (let [k# (key m#)
                v# (val m#)]
            (.writeFieldName ~jg (if (keyword? k#)
                                   (.substring (str k#) 1)
                                   (str k#)))
-           (generate ~jg v# ~date-format ~e nil
-                     :wholeness (if (= ~wholeness :start-inner)
-                                  :start
-                                  :all))))
-       (write-end-object ~jg ~wholeness))))
+           (generate ~jg v# inner-opts#)))
+       (write-end-object ~jg wholeness#))))
 
 (definline generate-key-fn-map
-  [^JsonGenerator jg obj ^String date-format ^Exception e
-   key-fn wholeness]
+  [^JsonGenerator jg obj opts]
   (let [k (gensym 'k)
         name (gensym 'name)
         jg (tag jg)]
-    `(do
-       (write-start-object ~jg ~wholeness)
+    `(let [key-fn# (:key-fn ~opts)
+           wholeness# (:wholeness ~opts)
+           inner-opts# (assoc ~opts :wholeness
+                              (if (= wholeness# :start-inner)
+                                :start
+                                :all))]
+       (write-start-object ~jg wholeness#)
        (doseq [m# ~obj]
          (let [~k (key m#)
                v# (val m#)
                ^String name# (if (keyword? ~k)
-                               (~key-fn ~k)
+                               (key-fn# ~k)
                                (str ~k))]
            (.writeFieldName ~jg name#)
-           (generate ~jg v# ~date-format ~e ~key-fn
-                     :wholeness (if (= ~wholeness :start-inner)
-                                  :start
-                                  :all))))
-       (write-end-object ~jg ~wholeness))))
+           (generate ~jg v# inner-opts#)))
+       (write-end-object ~jg wholeness#))))
 
 (definline generate-map
-  [^JsonGenerator jg obj ^String date-format ^Exception e
-   key-fn wholeness]
-  `(if (nil? ~key-fn)
-     (generate-basic-map ~jg ~obj ~date-format ~e ~wholeness)
-     (generate-key-fn-map ~jg ~obj ~date-format ~e ~key-fn ~wholeness)))
+  [^JsonGenerator jg obj opts]
+  `(if (nil? (:key-fn ~opts))
+     (generate-basic-map ~jg ~obj ~opts)
+     (generate-key-fn-map ~jg ~obj ~opts)))
 
-(definline generate-array [^JsonGenerator jg obj ^String date-format
-                           ^Exception e key-fn wholeness]
+(definline generate-array [^JsonGenerator jg obj opts]
   (let [jg (tag jg)]
-    `(do
-       (write-start-array ~jg ~wholeness)
-       (doseq [item# ~obj]
-         (generate ~jg item# ~date-format ~e ~key-fn
-                   :wholeness (if (= ~wholeness :start-inner)
+    `(let [wholeness# (:wholeness ~opts)
+           inner-opts# (assoc ~opts :wholeness
+                              (if (= wholeness# :start-inner)
                                 :start
-                                :all)))
-       (write-end-array ~jg ~wholeness))))
+                                :all))]
+       (write-start-array ~jg wholeness#)
+       (doseq [item# ~obj]
+         (generate ~jg item# inner-opts#))
+       (write-end-array ~jg wholeness#))))
 
-(defn generate [^JsonGenerator jg obj ^String date-format
-                ^Exception ex key-fn & {:keys [wholeness]}]
-  (let [wholeness (or wholeness :all)]
+(defn generate [^JsonGenerator jg obj opts]
+  (let [opts (if (:wholeness opts)
+               opts
+               (assoc opts :wholeness :all))]
     (cond
-     (nil? obj) (.writeNull ^JsonGenerator jg)
-     (get (:impls JSONable) (class obj)) (#'to-json obj jg)
+      (nil? obj) (.writeNull ^JsonGenerator jg)
+      (get (:impls JSONable) (class obj)) (#'to-json obj jg)
 
-     (i? IPersistentCollection obj)
-     (condp instance? obj
-       clojure.lang.IPersistentMap
-       (generate-map jg obj date-format ex key-fn wholeness)
-       clojure.lang.IPersistentVector
-       (generate-array jg obj date-format ex key-fn wholeness)
-       clojure.lang.IPersistentSet
-       (generate-array jg obj date-format ex key-fn wholeness)
-       clojure.lang.IPersistentList
-       (generate-array jg obj date-format ex key-fn wholeness)
-       clojure.lang.ISeq
-       (generate-array jg obj date-format ex key-fn wholeness)
-       clojure.lang.Associative
-       (generate-map jg obj date-format ex key-fn wholeness))
+      (i? IPersistentCollection obj)
+      (condp instance? obj
+        clojure.lang.IPersistentMap
+        (generate-map jg obj opts)
+        clojure.lang.IPersistentVector
+        (generate-array jg obj opts)
+        clojure.lang.IPersistentSet
+        (generate-array jg obj opts)
+        clojure.lang.IPersistentList
+        (generate-array jg obj opts)
+        clojure.lang.ISeq
+        (generate-array jg obj opts)
+        clojure.lang.Associative
+        (generate-map jg obj opts))
 
-     (i? Number obj) (number-dispatch ^JsonGenerator jg obj ex)
-     (i? Boolean obj) (.writeBoolean ^JsonGenerator jg ^Boolean obj)
-     (i? String obj) (write-string ^JsonGenerator jg ^String obj)
-     (i? Character obj) (write-string ^JsonGenerator jg ^String (str obj))
-     (i? Keyword obj) (write-string ^JsonGenerator jg (.substring (str obj) 1))
-     (i? Map obj) (generate-map jg obj date-format ex key-fn wholeness)
-     (i? List obj) (generate-array jg obj date-format ex key-fn wholeness)
-     (i? Set obj) (generate-array jg obj date-format ex key-fn wholeness)
-     (i? UUID obj) (write-string ^JsonGenerator jg (.toString ^UUID obj))
-     (i? Symbol obj) (write-string ^JsonGenerator jg (.toString ^Symbol obj))
-     (i? Date obj) (let [sdf (doto (SimpleDateFormat. date-format)
-                               (.setTimeZone (SimpleTimeZone. 0 "UTC")))]
-                     (write-string ^JsonGenerator jg (.format sdf obj)))
-     (i? Timestamp obj) (let [date (Date. (.getTime ^Timestamp obj))
-                              sdf (doto (SimpleDateFormat. date-format)
-                                    (.setTimeZone (SimpleTimeZone. 0 "UTC")))]
-                          (write-string ^JsonGenerator jg (.format sdf obj)))
-     :else (fail obj jg ex))))
+      (i? Number obj) (number-dispatch ^JsonGenerator jg obj (:ex opts))
+      (i? Boolean obj) (.writeBoolean ^JsonGenerator jg ^Boolean obj)
+      (i? String obj) (write-string ^JsonGenerator jg ^String obj)
+      (i? Character obj) (write-string ^JsonGenerator jg ^String (str obj))
+      (i? Keyword obj) (write-string ^JsonGenerator jg (.substring (str obj) 1))
+      (i? Map obj) (generate-map jg obj opts)
+      (i? List obj) (generate-array jg obj opts)
+      (i? Set obj) (generate-array jg obj opts)
+      (i? UUID obj) (write-string ^JsonGenerator jg (.toString ^UUID obj))
+      (i? Symbol obj) (write-string ^JsonGenerator jg (.toString ^Symbol obj))
+      (i? Date obj) (let [^String date-format (:date-format opts)
+                          sdf (doto (SimpleDateFormat. date-format)
+                                (.setTimeZone (SimpleTimeZone. 0 "UTC")))]
+                      (write-string ^JsonGenerator jg (.format sdf obj)))
+      (i? Timestamp obj) (let [^String date-format (:date-format opts)
+                               date (Date. (.getTime ^Timestamp obj))
+                               sdf (doto (SimpleDateFormat. date-format)
+                                     (.setTimeZone (SimpleTimeZone. 0 "UTC")))]
+                           (write-string ^JsonGenerator jg (.format sdf obj)))
+      :else (fail obj jg (:ex opts)))))


### PR DESCRIPTION
Many internal functions had two or three arguments for customizing
behavior. Since we'd like to be able to add more customization in the
future, condensing these into an options map seems like a good move.

One subtle difference introduced is that the functions which previously
read a :date-format value from a map and used `or` to determine whether
to used the default-date-format, now use `merge` and so have different
behavior if the `:date-format` key is present but `nil`. I'm assuming
this will be fine.