### PR TITLE
Support byte-array (de)serialization

### DIFF
--- a/src/cheshire/generate.clj
+++ b/src/cheshire/generate.clj
@@ -108,6 +108,11 @@
   ;;(println :inst? k obj)
   `(instance? ~k ~obj))
 
+(defn byte-array? [o]
+  (let [c (class o)]
+    (and (.isArray c)
+         (identical? (.getComponentType c) Byte/TYPE))))
+
 (defn generate [^JsonGenerator jg obj ^String date-format ^Exception ex key-fn]
   (cond
    (nil? obj) (.writeNull ^JsonGenerator jg)
@@ -128,6 +133,7 @@
      clojure.lang.Associative
      (generate-map jg obj date-format ex key-fn))
 
+   (byte-array? obj) (.writeBinary ^JsonGenerator jg ^bytes obj)
    (i? Number obj) (number-dispatch ^JsonGenerator jg obj ex)
    (i? Boolean obj) (.writeBoolean ^JsonGenerator jg ^Boolean obj)
    (i? String obj) (write-string ^JsonGenerator jg ^String obj)

--- a/src/cheshire/parse.clj
+++ b/src/cheshire/parse.clj
@@ -67,6 +67,7 @@
     JsonToken/VALUE_NUMBER_FLOAT (if bd?
                                    (.getDecimalValue jp)
                                    (.getNumberValue jp))
+    JsonToken/VALUE_EMBEDDED_OBJECT (.getBinaryValue jp)
     JsonToken/VALUE_TRUE true
     JsonToken/VALUE_FALSE false
     JsonToken/VALUE_NULL nil

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -106,6 +106,17 @@
 (deftest test-smile-round-trip
   (is (= test-obj (json/parse-smile (json/generate-smile test-obj)))))
 
+(def bin-obj {"byte-array" (byte-array (map byte [1 2 3]))})
+
+(deftest test-round-trip-binary
+  (for [[p g] {json/parse-string json/generate-string
+               json/parse-smile  json/generate-smile
+               json/parse-cbor   json/generate-cbor}]
+    (is (let [roundtripped (p (g bin-obj))]
+          ;; test value equality
+          (= (->> bin-obj (get "byte-array") seq)
+             (->> roundtripped (get "byte-array") seq))))))
+
 (deftest test-aliases
   (is (= {"foo" "bar" "1" "bat" "2" "bang" "3" "biz"}
          (json/decode


### PR DESCRIPTION
Using jackson's own .writeBinary generation, which
is  base64 by default for regular JSON, and efficient
byte-strings for smile/cbor .

Meanwhile, my current monkey patch for deserialization is:

```clj
(import '(com.fasterxml.jackson.core JsonParser JsonToken))
(alter-var-root
  #'cheshire.parse/parse* (fn [orig]
                (fn [^JsonParser jp key-fn bd? array-coerce-fn]
                  (if (identical? JsonToken/VALUE_EMBEDDED_OBJECT (.getCurrentToken jp))
                    (.getBinaryValue jp)
                    (orig jp key-fn bd? array-coerce-fn)))))
```