### PR TITLE
Custom pretty print options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ pom.xml*
 doc*
 .lein*
 .nrepl*
+.idea
+*.iml
+.DS_Store

--- a/benchmarks/cheshire/test/benchmark.clj
+++ b/benchmarks/cheshire/test/benchmark.clj
@@ -1,12 +1,12 @@
 (ns cheshire.test.benchmark
   (:use [clojure.test])
-    (:require [cheshire.core :as core]
-      [cheshire.custom :as old]
-      [cheshire.generate :as custom]
-      [clojure.data.json :as cj]
-      [clojure.java.io :refer [file input-stream resource]]
-      [clj-json.core :as clj-json]
-      [criterium.core :as bench] [cheshire.core :as core])
+  (:require [cheshire.core :as core]
+            [cheshire.custom :as old]
+            [cheshire.generate :as custom]
+            [clojure.data.json :as cj]
+            [clojure.java.io :refer [file input-stream resource]]
+            [clj-json.core :as clj-json]
+            [criterium.core :as bench])
   (:import (java.util.zip GZIPInputStream)))
 
 ;; These tests just print out results, nothing else, they also
@@ -69,36 +69,36 @@
   (custom/add-encoder java.net.URL custom/encode-str)
   (is (= "\"http://foo.com\"" (core/encode (java.net.URL. "http://foo.com"))))
   (let [custom-obj (assoc test-obj "url" (java.net.URL. "http://foo.com"))]
-       (println "[+] Custom, all custom fields:")
-       (bench/with-progress-reporting
-         (bench/quick-bench (core/decode (core/encode custom-obj)) :verbose)))
+    (println "[+] Custom, all custom fields:")
+    (bench/with-progress-reporting
+      (bench/quick-bench (core/decode (core/encode custom-obj)) :verbose)))
   (println "-------------------------------------"))
 
 (deftest t-bench-custom-kw-coercion
   (println "---- Custom keyword-fn Benchmarks ---")
   (let [t (core/encode test-obj)]
-       (println "[+] (fn [k] (keyword k)) decode")
-       (bench/with-progress-reporting
-         (bench/quick-bench (core/decode t (fn [k] (keyword k)))))
-       (println "[+] basic 'true' keyword-fn decode")
-       (bench/with-progress-reporting
-         (bench/quick-bench (core/decode t true)))
-       (println "[+] no keyword-fn decode")
-       (bench/with-progress-reporting
-         (bench/quick-bench (core/decode t)))
-       (println "[+] (fn [k] (name k)) encode")
-       (bench/with-progress-reporting
-         (bench/quick-bench (core/encode test-obj {:key-fn (fn [k] (name k))})))
-       (println "[+] no keyword-fn encode")
-       (bench/with-progress-reporting
-         (bench/quick-bench (core/encode test-obj))))
+    (println "[+] (fn [k] (keyword k)) decode")
+    (bench/with-progress-reporting
+      (bench/quick-bench (core/decode t (fn [k] (keyword k)))))
+    (println "[+] basic 'true' keyword-fn decode")
+    (bench/with-progress-reporting
+      (bench/quick-bench (core/decode t true)))
+    (println "[+] no keyword-fn decode")
+    (bench/with-progress-reporting
+      (bench/quick-bench (core/decode t)))
+    (println "[+] (fn [k] (name k)) encode")
+    (bench/with-progress-reporting
+      (bench/quick-bench (core/encode test-obj {:key-fn (fn [k] (name k))})))
+    (println "[+] no keyword-fn encode")
+    (bench/with-progress-reporting
+      (bench/quick-bench (core/encode test-obj))))
   (println "-------------------------------------"))
 
 (deftest t-large-array
   (println "-------- Large array parsing --------")
   (let [test-array-json (core/encode (range 1024))]
-       (bench/with-progress-reporting
-         (bench/bench (pr-str (core/decode test-array-json)))))
+    (bench/with-progress-reporting
+      (bench/bench (pr-str (core/decode test-array-json)))))
   (println "-------------------------------------"))
 
 (deftest t-large-geojson-object
@@ -111,6 +111,6 @@
     (bench/quick-bench (core/encode big-test-obj)))
   (println "[+] large geojson decode")
   (let [s (core/encode big-test-obj)]
-       (bench/with-progress-reporting
-         (bench/quick-bench (core/decode s))))
+    (bench/with-progress-reporting
+      (bench/quick-bench (core/decode s))))
   (println "-------------------------------------"))

--- a/benchmarks/cheshire/test/benchmark.clj
+++ b/benchmarks/cheshire/test/benchmark.clj
@@ -1,12 +1,12 @@
 (ns cheshire.test.benchmark
   (:use [clojure.test])
-  (:require [cheshire.core :as core]
-            [cheshire.custom :as old]
-            [cheshire.generate :as custom]
-            [clojure.data.json :as cj]
-            [clojure.java.io :refer [file input-stream resource]]
-            [clj-json.core :as clj-json]
-            [criterium.core :as bench])
+    (:require [cheshire.core :as core]
+      [cheshire.custom :as old]
+      [cheshire.generate :as custom]
+      [clojure.data.json :as cj]
+      [clojure.java.io :refer [file input-stream resource]]
+      [clj-json.core :as clj-json]
+      [criterium.core :as bench] [cheshire.core :as core])
   (:import (java.util.zip GZIPInputStream)))
 
 ;; These tests just print out results, nothing else, they also
@@ -25,9 +25,9 @@
                "keyword" :foo})
 
 (def test-pretty-opts
-  {:pretty {:indentation 4
-            :indent-arrays? true
-            :object-field-value-separator ": "}})
+  {:indentation 4
+   :indent-arrays? true
+   :object-field-value-separator ": "})
 
 (def big-test-obj
   (-> "test/all_month.geojson.gz"
@@ -57,47 +57,48 @@
   (println "-------------------------------------"))
 
 (deftest t-bench-pretty
-  (println "------- PrettyPrint Benchmarks ------")
-  (println "........default pretty printer")
-  (bench/bench (core/encode test-obj {:pretty true}))
-  (println "........custom pretty printer")
-  (bench/bench (core/encode test-obj test-pretty-opts)))
+  (let [pretty-printer (core/create-pretty-printer test-pretty-opts)]
+    (println "------- PrettyPrint Benchmarks ------")
+    (println "........default pretty printer")
+    (bench/bench (core/encode test-obj {:pretty true}))
+    (println "........custom pretty printer")
+    (bench/bench (core/encode test-obj {:pretty pretty-printer}))))
 
 (deftest t-bench-custom
   (println "--------- Custom Benchmarks ---------")
   (custom/add-encoder java.net.URL custom/encode-str)
   (is (= "\"http://foo.com\"" (core/encode (java.net.URL. "http://foo.com"))))
   (let [custom-obj (assoc test-obj "url" (java.net.URL. "http://foo.com"))]
-    (println "[+] Custom, all custom fields:")
-    (bench/with-progress-reporting
-      (bench/quick-bench (core/decode (core/encode custom-obj)) :verbose)))
+       (println "[+] Custom, all custom fields:")
+       (bench/with-progress-reporting
+         (bench/quick-bench (core/decode (core/encode custom-obj)) :verbose)))
   (println "-------------------------------------"))
 
 (deftest t-bench-custom-kw-coercion
   (println "---- Custom keyword-fn Benchmarks ---")
   (let [t (core/encode test-obj)]
-    (println "[+] (fn [k] (keyword k)) decode")
-    (bench/with-progress-reporting
-      (bench/quick-bench (core/decode t (fn [k] (keyword k)))))
-    (println "[+] basic 'true' keyword-fn decode")
-    (bench/with-progress-reporting
-      (bench/quick-bench (core/decode t true)))
-    (println "[+] no keyword-fn decode")
-    (bench/with-progress-reporting
-      (bench/quick-bench (core/decode t)))
-    (println "[+] (fn [k] (name k)) encode")
-    (bench/with-progress-reporting
-      (bench/quick-bench (core/encode test-obj {:key-fn (fn [k] (name k))})))
-    (println "[+] no keyword-fn encode")
-    (bench/with-progress-reporting
-      (bench/quick-bench (core/encode test-obj))))
+       (println "[+] (fn [k] (keyword k)) decode")
+       (bench/with-progress-reporting
+         (bench/quick-bench (core/decode t (fn [k] (keyword k)))))
+       (println "[+] basic 'true' keyword-fn decode")
+       (bench/with-progress-reporting
+         (bench/quick-bench (core/decode t true)))
+       (println "[+] no keyword-fn decode")
+       (bench/with-progress-reporting
+         (bench/quick-bench (core/decode t)))
+       (println "[+] (fn [k] (name k)) encode")
+       (bench/with-progress-reporting
+         (bench/quick-bench (core/encode test-obj {:key-fn (fn [k] (name k))})))
+       (println "[+] no keyword-fn encode")
+       (bench/with-progress-reporting
+         (bench/quick-bench (core/encode test-obj))))
   (println "-------------------------------------"))
 
 (deftest t-large-array
   (println "-------- Large array parsing --------")
   (let [test-array-json (core/encode (range 1024))]
-    (bench/with-progress-reporting
-      (bench/bench (pr-str (core/decode test-array-json)))))
+       (bench/with-progress-reporting
+         (bench/bench (pr-str (core/decode test-array-json)))))
   (println "-------------------------------------"))
 
 (deftest t-large-geojson-object
@@ -110,6 +111,6 @@
     (bench/quick-bench (core/encode big-test-obj)))
   (println "[+] large geojson decode")
   (let [s (core/encode big-test-obj)]
-    (bench/with-progress-reporting
-      (bench/quick-bench (core/decode s))))
+       (bench/with-progress-reporting
+         (bench/quick-bench (core/decode s))))
   (println "-------------------------------------"))

--- a/benchmarks/cheshire/test/benchmark.clj
+++ b/benchmarks/cheshire/test/benchmark.clj
@@ -26,7 +26,8 @@
 
 (def test-pretty-opts
   {:pretty {:indentation 4
-            :object-key-value-separator ": "}})
+            :indent-arrays? true
+            :object-field-value-separator ": "}})
 
 (def big-test-obj
   (-> "test/all_month.geojson.gz"
@@ -57,8 +58,6 @@
 
 (deftest t-bench-pretty
   (println "------- PrettyPrint Benchmarks ------")
-  (println "........without pretty printer")
-  (bench/bench (core/encode test-obj))
   (println "........default pretty printer")
   (bench/bench (core/encode test-obj {:pretty true}))
   (println "........custom pretty printer")

--- a/benchmarks/cheshire/test/benchmark.clj
+++ b/benchmarks/cheshire/test/benchmark.clj
@@ -24,6 +24,10 @@
                "set" #{"a" "b"}
                "keyword" :foo})
 
+(def test-pretty-opts
+  {:pretty {:indentation 4
+            :object-key-value-separator ": "}})
+
 (def big-test-obj
   (-> "test/all_month.geojson.gz"
       file
@@ -50,6 +54,15 @@
   (bench/with-progress-reporting
     (bench/bench (core/decode (core/encode test-obj)) :verbose))
   (println "-------------------------------------"))
+
+(deftest t-bench-pretty
+  (println "------- PrettyPrint Benchmarks ------")
+  (println "........without pretty printer")
+  (bench/bench (core/encode test-obj))
+  (println "........default pretty printer")
+  (bench/bench (core/encode test-obj {:pretty true}))
+  (println "........custom pretty printer")
+  (bench/bench (core/encode test-obj test-pretty-opts)))
 
 (deftest t-bench-custom
   (println "--------- Custom Benchmarks ---------")

--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,8 @@
                                         [clj-json "0.5.3"]]}}
   :aliases {"all" ["with-profile" "dev,1.3:dev,1.4:dev,1.5:dev,1.7:dev,1.8:dev"]
             "benchmark" ["with-profile" "dev,benchmark" "test"]
+            "pretty-bench" ["with-profile" "dev,benchmark" "test" ":only"
+                          "cheshire.test.benchmark/t-bench-pretty"]
             "core-bench" ["with-profile" "dev,benchmark" "test" ":only"
                           "cheshire.test.benchmark/t-bench-core"]}
   :test-selectors {:default  #(and (not (:benchmark %))

--- a/project.clj
+++ b/project.clj
@@ -33,6 +33,7 @@
                    :generative :generative
                    :all (constantly true)}
   :plugins [[codox "0.6.3"]]
+  :java-source-paths ["src/java"]
   :jvm-opts ["-Xmx512M"
 ;;             "-XX:+PrintCompilation"
 ;;             "-XX:+UnlockDiagnosticVMOptions"

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -59,14 +59,15 @@
                                      factory/json-factory)
                     ^Writer sw)
          print-pretty (:pretty opt-map)]
-     (condp instance? print-pretty
-       Boolean
-         (.useDefaultPrettyPrinter generator)
-       clojure.lang.IPersistentMap
-         (.setPrettyPrinter generator (create-pretty-printer print-pretty))
-       PrettyPrinter
-         (.setPrettyPrinter generator print-pretty)
-       nil)
+     (when print-pretty
+       (condp instance? print-pretty
+         Boolean
+           (.useDefaultPrettyPrinter generator)
+         clojure.lang.IPersistentMap
+           (.setPrettyPrinter generator (create-pretty-printer print-pretty))
+         PrettyPrinter
+           (.setPrettyPrinter generator print-pretty)
+         nil))
      (when (:escape-non-ascii opt-map)
        (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
      (gen/generate generator obj
@@ -90,14 +91,15 @@
                                      factory/json-factory)
                     ^Writer writer)
          print-pretty (:pretty opt-map)]
-     (condp instance? print-pretty
-       Boolean
-         (.useDefaultPrettyPrinter generator)
-       clojure.lang.IPersistentMap
-         (.setPrettyPrinter generator (create-pretty-printer print-pretty))
-       PrettyPrinter
-         (.setPrettyPrinter generator print-pretty)
-       nil)
+     (when print-pretty
+       (condp instance? print-pretty
+         Boolean
+       (.useDefaultPrettyPrinter generator)
+         clojure.lang.IPersistentMap
+       (.setPrettyPrinter generator (create-pretty-printer print-pretty))
+         PrettyPrinter
+       (.setPrettyPrinter generator print-pretty)
+         nil))
      (when (:escape-non-ascii opt-map)
        (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
      (gen/generate generator obj (or (:date-format opt-map)

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -1,315 +1,315 @@
 (ns cheshire.core
-	"Main encoding and decoding namespace."
-	(:require [cheshire.factory :as factory]
-						[cheshire.generate :as gen]
-						[cheshire.generate-seq :as gen-seq]
-						[cheshire.parse :as parse])
-	(:import (com.fasterxml.jackson.core JsonParser JsonFactory
-																			 JsonGenerator
-																			 JsonGenerator$Feature)
-					 (com.fasterxml.jackson.dataformat.smile SmileFactory)
-					 (cheshire.prettyprint CustomPrettyPrinter)
-					 (java.io StringWriter StringReader BufferedReader BufferedWriter
-										ByteArrayOutputStream OutputStream Reader Writer)))
+  "Main encoding and decoding namespace."
+  (:require [cheshire.factory :as factory]
+            [cheshire.generate :as gen]
+            [cheshire.generate-seq :as gen-seq]
+            [cheshire.parse :as parse])
+  (:import (com.fasterxml.jackson.core JsonParser JsonFactory
+                                       JsonGenerator
+                                       JsonGenerator$Feature)
+           (com.fasterxml.jackson.dataformat.smile SmileFactory)
+           (cheshire.prettyprint CustomPrettyPrinter)
+           (java.io StringWriter StringReader BufferedReader BufferedWriter
+                    ByteArrayOutputStream OutputStream Reader Writer)))
 
 (def ^:private default-pretty-print-options
-	{:indentation 2
-	 :indent-arrays? false
-	 :indent-objects? true
-	 :before-array-values nil
-	 :after-array-values nil
-	 :object-field-value-separator nil})
+  {:indentation 2
+   :indent-arrays? false
+   :indent-objects? true
+   :before-array-values nil
+   :after-array-values nil
+   :object-field-value-separator nil})
 
 (defn- create-pretty-printer
-	"Returns an instance of CustomPrettyPrinter based on the configuration
-	provided as argument"
-	[options]
-	(let [{:keys [indentation
-								indent-arrays?
-								indent-objects?
-								before-array-values
-								after-array-values
-								object-field-value-separator]} (merge default-pretty-print-options options)]
-		(-> (new CustomPrettyPrinter)
-				(.setIndentation indentation indent-objects? indent-arrays?)
-				(.setBeforeArrayValues before-array-values)
-				(.setAfterArrayValues after-array-values)
-				(.setObjectFieldValueSeparator object-field-value-separator))))
+  "Returns an instance of CustomPrettyPrinter based on the configuration
+  provided as argument"
+  [options]
+  (let [{:keys [indentation
+                indent-arrays?
+                indent-objects?
+                before-array-values
+                after-array-values
+                object-field-value-separator]} (merge default-pretty-print-options options)]
+    (-> (new CustomPrettyPrinter)
+        (.setIndentation indentation indent-objects? indent-arrays?)
+        (.setBeforeArrayValues before-array-values)
+        (.setAfterArrayValues after-array-values)
+        (.setObjectFieldValueSeparator object-field-value-separator))))
 
 ;; Generators
 (defn ^String generate-string
-	"Returns a JSON-encoding String for the given Clojure object. Takes an
-	optional date format string that Date objects will be encoded with.
+  "Returns a JSON-encoding String for the given Clojure object. Takes an
+  optional date format string that Date objects will be encoded with.
 
-	The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-	([obj]
-	 (generate-string obj nil))
-	([obj opt-map]
-	 (let [sw (StringWriter.)
-				 generator (.createGenerator
-										^JsonFactory (or factory/*json-factory*
-																		 factory/json-factory)
-										^Writer sw)
-				 print-pretty (:pretty opt-map)]
-		 (when print-pretty
-			 (if (= true print-pretty)
-				 (.useDefaultPrettyPrinter generator)
-				 (.setPrettyPrinter generator (create-pretty-printer print-pretty))))
-		 (when (:escape-non-ascii opt-map)
-			 (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
-		 (gen/generate generator obj
-									 (or (:date-format opt-map) factory/default-date-format)
-									 (:ex opt-map)
-									 (:key-fn opt-map))
-		 (.flush generator)
-		 (.toString sw))))
+  The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
+  ([obj]
+   (generate-string obj nil))
+  ([obj opt-map]
+   (let [sw (StringWriter.)
+         generator (.createGenerator
+                    ^JsonFactory (or factory/*json-factory*
+                                     factory/json-factory)
+                    ^Writer sw)
+         print-pretty (:pretty opt-map)]
+     (when print-pretty
+       (if (= true print-pretty)
+         (.useDefaultPrettyPrinter generator)
+         (.setPrettyPrinter generator (create-pretty-printer print-pretty))))
+     (when (:escape-non-ascii opt-map)
+       (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
+     (gen/generate generator obj
+                   (or (:date-format opt-map) factory/default-date-format)
+                   (:ex opt-map)
+                   (:key-fn opt-map))
+     (.flush generator)
+     (.toString sw))))
 
 (defn ^BufferedWriter generate-stream
-	"Returns a BufferedWriter for the given Clojure object with the JSON-encoded
-	data written to the writer. Takes an optional date format string that Date
-	objects will be encoded with.
+  "Returns a BufferedWriter for the given Clojure object with the JSON-encoded
+  data written to the writer. Takes an optional date format string that Date
+  objects will be encoded with.
 
-	The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-	([obj ^BufferedWriter writer]
-	 (generate-stream obj writer nil))
-	([obj ^BufferedWriter writer opt-map]
-	 (let [generator (.createGenerator
-										^JsonFactory (or factory/*json-factory*
-																		 factory/json-factory)
-										^Writer writer)
-				 print-pretty (:pretty opt-map)]
-		 (when print-pretty
-			 (if (= true print-pretty)
-				 (.useDefaultPrettyPrinter generator)
-				 (.setPrettyPrinter generator (create-pretty-printer print-pretty))))
-		 (when (:escape-non-ascii opt-map)
-			 (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
-		 (gen/generate generator obj (or (:date-format opt-map)
-																		 factory/default-date-format)
-									 (:ex opt-map)
-									 (:key-fn opt-map))
-		 (.flush generator)
-		 writer)))
+  The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
+  ([obj ^BufferedWriter writer]
+   (generate-stream obj writer nil))
+  ([obj ^BufferedWriter writer opt-map]
+   (let [generator (.createGenerator
+                    ^JsonFactory (or factory/*json-factory*
+                                     factory/json-factory)
+                    ^Writer writer)
+         print-pretty (:pretty opt-map)]
+     (when print-pretty
+       (if (= true print-pretty)
+         (.useDefaultPrettyPrinter generator)
+         (.setPrettyPrinter generator (create-pretty-printer print-pretty))))
+     (when (:escape-non-ascii opt-map)
+       (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
+     (gen/generate generator obj (or (:date-format opt-map)
+                                     factory/default-date-format)
+                   (:ex opt-map)
+                   (:key-fn opt-map))
+     (.flush generator)
+     writer)))
 
 (defn create-generator [writer]
-	"Returns JsonGenerator for given writer."
-	(.createGenerator
-	 ^JsonFactory (or factory/*json-factory*
-										factory/json-factory)
-	 ^Writer writer))
+  "Returns JsonGenerator for given writer."
+  (.createGenerator
+   ^JsonFactory (or factory/*json-factory*
+                    factory/json-factory)
+   ^Writer writer))
 
 (def ^:dynamic ^JsonGenerator *generator*)
 (def ^:dynamic *opt-map*)
 
 (defmacro with-writer [[writer opt-map] & body]
-	"Start writing for series objects using the same json generator.
-	 Takes writer and options map as arguments.
-	 Expects its body as sequence of write calls.
-	 Returns a given writer."
-	`(let [c-wr# ~writer]
-		 (binding [*generator* (create-generator c-wr#)
-							 *opt-map* ~opt-map]
-			 ~@body
-			 (.flush *generator*)
-			 c-wr#)))
+  "Start writing for series objects using the same json generator.
+   Takes writer and options map as arguments.
+   Expects its body as sequence of write calls.
+   Returns a given writer."
+  `(let [c-wr# ~writer]
+     (binding [*generator* (create-generator c-wr#)
+               *opt-map* ~opt-map]
+       ~@body
+       (.flush *generator*)
+       c-wr#)))
 
 (defn write
-	"Write given Clojure object as a piece of data within with-writer.
-	List of wholeness acceptable values:
-	- no value - the same as :all
-	- :all - write object in a regular way with start and end borders
-	- :start - write object with start border only
-	- :start-inner - write object and its inner object with start border only
-	- :end - write object with end border only."
-	([obj] (write obj nil))
-	([obj wholeness]
-	 (gen-seq/generate *generator* obj (or (:date-format *opt-map*)
-																				 factory/default-date-format)
-										 (:ex *opt-map*)
-										 (:key-fn *opt-map*)
-										 :wholeness wholeness)))
+  "Write given Clojure object as a piece of data within with-writer.
+  List of wholeness acceptable values:
+  - no value - the same as :all
+  - :all - write object in a regular way with start and end borders
+  - :start - write object with start border only
+  - :start-inner - write object and its inner object with start border only
+  - :end - write object with end border only."
+  ([obj] (write obj nil))
+  ([obj wholeness]
+   (gen-seq/generate *generator* obj (or (:date-format *opt-map*)
+                                         factory/default-date-format)
+                     (:ex *opt-map*)
+                     (:key-fn *opt-map*)
+                     :wholeness wholeness)))
 
 (defn generate-smile
-	"Returns a SMILE-encoded byte-array for the given Clojure object.
-	Takes an optional date format string that Date objects will be encoded with.
+  "Returns a SMILE-encoded byte-array for the given Clojure object.
+  Takes an optional date format string that Date objects will be encoded with.
 
-	The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-	([obj]
-	 (generate-smile obj nil))
-	([obj opt-map]
-	 (let [baos (ByteArrayOutputStream.)
-				 generator (.createGenerator ^SmileFactory
-																		 (or factory/*smile-factory*
-																				 factory/smile-factory)
-																		 ^OutputStream baos)]
-		 (gen/generate generator obj (or (:date-format opt-map)
-																		 factory/default-date-format)
-									 (:ex opt-map)
-									 (:key-fn opt-map))
-		 (.flush generator)
-		 (.toByteArray baos))))
+  The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
+  ([obj]
+   (generate-smile obj nil))
+  ([obj opt-map]
+   (let [baos (ByteArrayOutputStream.)
+         generator (.createGenerator ^SmileFactory
+                                     (or factory/*smile-factory*
+                                         factory/smile-factory)
+                                     ^OutputStream baos)]
+     (gen/generate generator obj (or (:date-format opt-map)
+                                     factory/default-date-format)
+                   (:ex opt-map)
+                   (:key-fn opt-map))
+     (.flush generator)
+     (.toByteArray baos))))
 
 (defn generate-cbor
-	"Returns a CBOR-encoded byte-array for the given Clojure object.
-	Takes an optional date format string that Date objects will be encoded with.
+  "Returns a CBOR-encoded byte-array for the given Clojure object.
+  Takes an optional date format string that Date objects will be encoded with.
 
-	The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-	([obj]
-	 (generate-cbor obj nil))
-	([obj opt-map]
-	 (let [baos (ByteArrayOutputStream.)
-				 generator (.createGenerator ^CBORFactory
-																		 (or factory/*cbor-factory*
-																				 factory/cbor-factory)
-																		 ^OutputStream baos)]
-		 (gen/generate generator obj (or (:date-format opt-map)
-																		 factory/default-date-format)
-									 (:ex opt-map)
-									 (:key-fn opt-map))
-		 (.flush generator)
-		 (.toByteArray baos))))
+  The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
+  ([obj]
+   (generate-cbor obj nil))
+  ([obj opt-map]
+   (let [baos (ByteArrayOutputStream.)
+         generator (.createGenerator ^CBORFactory
+                                     (or factory/*cbor-factory*
+                                         factory/cbor-factory)
+                                     ^OutputStream baos)]
+     (gen/generate generator obj (or (:date-format opt-map)
+                                     factory/default-date-format)
+                   (:ex opt-map)
+                   (:key-fn opt-map))
+     (.flush generator)
+     (.toByteArray baos))))
 
 ;; Parsers
 (defn parse-string
-	"Returns the Clojure object corresponding to the given JSON-encoded string.
-	An optional key-fn argument can be either true (to coerce keys to keywords),
-	false to leave them as strings, or a function to provide custom coercion.
+  "Returns the Clojure object corresponding to the given JSON-encoded string.
+  An optional key-fn argument can be either true (to coerce keys to keywords),
+  false to leave them as strings, or a function to provide custom coercion.
 
-	The array-coerce-fn is an optional function taking the name of an array field,
-	and returning the collection to be used for array values.
+  The array-coerce-fn is an optional function taking the name of an array field,
+  and returning the collection to be used for array values.
 
-	If the top-level object is an array, it will be parsed lazily (use
-	`parse-strict' if strict parsing is required for top-level arrays."
-	([string] (parse-string string nil nil))
-	([string key-fn] (parse-string string key-fn nil))
-	([^String string key-fn array-coerce-fn]
-	 (when string
-		 (parse/parse
-			(.createParser ^JsonFactory (or factory/*json-factory*
-																			factory/json-factory)
-										 ^Reader (StringReader. string))
-			key-fn nil array-coerce-fn))))
+  If the top-level object is an array, it will be parsed lazily (use
+  `parse-strict' if strict parsing is required for top-level arrays."
+  ([string] (parse-string string nil nil))
+  ([string key-fn] (parse-string string key-fn nil))
+  ([^String string key-fn array-coerce-fn]
+   (when string
+     (parse/parse
+      (.createParser ^JsonFactory (or factory/*json-factory*
+                                      factory/json-factory)
+                     ^Reader (StringReader. string))
+      key-fn nil array-coerce-fn))))
 
 ;; Parsing strictly
 (defn parse-string-strict
-	"Returns the Clojure object corresponding to the given JSON-encoded string.
-	An optional key-fn argument can be either true (to coerce keys to keywords),
-	false to leave them as strings, or a function to provide custom coercion.
+  "Returns the Clojure object corresponding to the given JSON-encoded string.
+  An optional key-fn argument can be either true (to coerce keys to keywords),
+  false to leave them as strings, or a function to provide custom coercion.
 
-	The array-coerce-fn is an optional function taking the name of an array field,
-	and returning the collection to be used for array values.
+  The array-coerce-fn is an optional function taking the name of an array field,
+  and returning the collection to be used for array values.
 
-	Does not lazily parse top-level arrays."
-	([string] (parse-string-strict string nil nil))
-	([string key-fn] (parse-string-strict string key-fn nil))
-	([^String string key-fn array-coerce-fn]
-	 (when string
-		 (parse/parse-strict
-			(.createParser ^JsonFactory (or factory/*json-factory*
-																			factory/json-factory)
-										 ^Writer (StringReader. string))
-			key-fn nil array-coerce-fn))))
+  Does not lazily parse top-level arrays."
+  ([string] (parse-string-strict string nil nil))
+  ([string key-fn] (parse-string-strict string key-fn nil))
+  ([^String string key-fn array-coerce-fn]
+   (when string
+     (parse/parse-strict
+      (.createParser ^JsonFactory (or factory/*json-factory*
+                                      factory/json-factory)
+                     ^Writer (StringReader. string))
+      key-fn nil array-coerce-fn))))
 
 (defn parse-stream
-	"Returns the Clojure object corresponding to the given reader, reader must
-	implement BufferedReader. An optional key-fn argument can be either true (to
-	coerce keys to keywords),false to leave them as strings, or a function to
-	provide custom coercion.
+  "Returns the Clojure object corresponding to the given reader, reader must
+  implement BufferedReader. An optional key-fn argument can be either true (to
+  coerce keys to keywords),false to leave them as strings, or a function to
+  provide custom coercion.
 
-	The array-coerce-fn is an optional function taking the name of an array field,
-	and returning the collection to be used for array values.
+  The array-coerce-fn is an optional function taking the name of an array field,
+  and returning the collection to be used for array values.
 
-	If the top-level object is an array, it will be parsed lazily (use
-	`parse-strict' if strict parsing is required for top-level arrays.
+  If the top-level object is an array, it will be parsed lazily (use
+  `parse-strict' if strict parsing is required for top-level arrays.
 
-	If multiple objects (enclosed in a top-level `{}' need to be parsed lazily,
-	see parsed-seq."
-	([rdr] (parse-stream rdr nil nil))
-	([rdr key-fn] (parse-stream rdr key-fn nil))
-	([^BufferedReader rdr key-fn array-coerce-fn]
-	 (when rdr
-		 (parse/parse
-			(.createParser ^JsonFactory (or factory/*json-factory*
-																			factory/json-factory)
-										 ^Reader rdr)
-			key-fn nil array-coerce-fn))))
+  If multiple objects (enclosed in a top-level `{}' need to be parsed lazily,
+  see parsed-seq."
+  ([rdr] (parse-stream rdr nil nil))
+  ([rdr key-fn] (parse-stream rdr key-fn nil))
+  ([^BufferedReader rdr key-fn array-coerce-fn]
+   (when rdr
+     (parse/parse
+      (.createParser ^JsonFactory (or factory/*json-factory*
+                                      factory/json-factory)
+                     ^Reader rdr)
+      key-fn nil array-coerce-fn))))
 
 (defn parse-smile
-	"Returns the Clojure object corresponding to the given SMILE-encoded bytes.
-	An optional key-fn argument can be either true (to coerce keys to keywords),
-	false to leave them as strings, or a function to provide custom coercion.
+  "Returns the Clojure object corresponding to the given SMILE-encoded bytes.
+  An optional key-fn argument can be either true (to coerce keys to keywords),
+  false to leave them as strings, or a function to provide custom coercion.
 
-	The array-coerce-fn is an optional function taking the name of an array field,
-	and returning the collection to be used for array values."
-	([bytes] (parse-smile bytes nil nil))
-	([bytes key-fn] (parse-smile bytes key-fn nil))
-	([^bytes bytes key-fn array-coerce-fn]
-	 (when bytes
-		 (parse/parse
-			(.createParser ^SmileFactory (or factory/*smile-factory*
-																			 factory/smile-factory) bytes)
-			key-fn nil array-coerce-fn))))
+  The array-coerce-fn is an optional function taking the name of an array field,
+  and returning the collection to be used for array values."
+  ([bytes] (parse-smile bytes nil nil))
+  ([bytes key-fn] (parse-smile bytes key-fn nil))
+  ([^bytes bytes key-fn array-coerce-fn]
+   (when bytes
+     (parse/parse
+      (.createParser ^SmileFactory (or factory/*smile-factory*
+                                       factory/smile-factory) bytes)
+      key-fn nil array-coerce-fn))))
 
 (defn parse-cbor
-	"Returns the Clojure object corresponding to the given CBOR-encoded bytes.
-	An optional key-fn argument can be either true (to coerce keys to keywords),
-	false to leave them as strings, or a function to provide custom coercion.
+  "Returns the Clojure object corresponding to the given CBOR-encoded bytes.
+  An optional key-fn argument can be either true (to coerce keys to keywords),
+  false to leave them as strings, or a function to provide custom coercion.
 
-	The array-coerce-fn is an optional function taking the name of an array field,
-	and returning the collection to be used for array values."
-	([bytes] (parse-cbor bytes nil nil))
-	([bytes key-fn] (parse-cbor bytes key-fn nil))
-	([^bytes bytes key-fn array-coerce-fn]
-	 (when bytes
-		 (parse/parse
-			(.createParser ^CBORFactory (or factory/*cbor-factory*
-																			factory/cbor-factory) bytes)
-			key-fn nil array-coerce-fn))))
+  The array-coerce-fn is an optional function taking the name of an array field,
+  and returning the collection to be used for array values."
+  ([bytes] (parse-cbor bytes nil nil))
+  ([bytes key-fn] (parse-cbor bytes key-fn nil))
+  ([^bytes bytes key-fn array-coerce-fn]
+   (when bytes
+     (parse/parse
+      (.createParser ^CBORFactory (or factory/*cbor-factory*
+                                      factory/cbor-factory) bytes)
+      key-fn nil array-coerce-fn))))
 
 (def ^{:doc "Object used to determine end of lazy parsing attempt."}
-	eof (Object.))
+  eof (Object.))
 
 ;; Lazy parsers
 (defn- parsed-seq*
-	"Internal lazy-seq parser"
-	[^JsonParser parser key-fn array-coerce-fn]
-	(lazy-seq
-	 (let [elem (parse/parse-strict parser key-fn eof array-coerce-fn)]
-		 (when-not (identical? elem eof)
-			 (cons elem (parsed-seq* parser key-fn array-coerce-fn))))))
+  "Internal lazy-seq parser"
+  [^JsonParser parser key-fn array-coerce-fn]
+  (lazy-seq
+   (let [elem (parse/parse-strict parser key-fn eof array-coerce-fn)]
+     (when-not (identical? elem eof)
+       (cons elem (parsed-seq* parser key-fn array-coerce-fn))))))
 
 (defn parsed-seq
-	"Returns a lazy seq of Clojure objects corresponding to the JSON read from
-	the given reader. The seq continues until the end of the reader is reached.
+  "Returns a lazy seq of Clojure objects corresponding to the JSON read from
+  the given reader. The seq continues until the end of the reader is reached.
 
-	The array-coerce-fn is an optional function taking the name of an array field,
-	and returning the collection to be used for array values.
-	If non-laziness is needed, see parse-stream."
-	([reader] (parsed-seq reader nil nil))
-	([reader key-fn] (parsed-seq reader key-fn nil))
-	([^BufferedReader reader key-fn array-coerce-fn]
-	 (when reader
-		 (parsed-seq* (.createParser ^JsonFactory
-																 (or factory/*json-factory*
-																		 factory/json-factory)
-																 ^Reader reader)
-									key-fn array-coerce-fn))))
+  The array-coerce-fn is an optional function taking the name of an array field,
+  and returning the collection to be used for array values.
+  If non-laziness is needed, see parse-stream."
+  ([reader] (parsed-seq reader nil nil))
+  ([reader key-fn] (parsed-seq reader key-fn nil))
+  ([^BufferedReader reader key-fn array-coerce-fn]
+   (when reader
+     (parsed-seq* (.createParser ^JsonFactory
+                                 (or factory/*json-factory*
+                                     factory/json-factory)
+                                 ^Reader reader)
+                  key-fn array-coerce-fn))))
 
 (defn parsed-smile-seq
-	"Returns a lazy seq of Clojure objects corresponding to the SMILE read from
-	the given reader. The seq continues until the end of the reader is reached.
+  "Returns a lazy seq of Clojure objects corresponding to the SMILE read from
+  the given reader. The seq continues until the end of the reader is reached.
 
-	The array-coerce-fn is an optional function taking the name of an array field,
-	and returning the collection to be used for array values."
-	([reader] (parsed-smile-seq reader nil nil))
-	([reader key-fn] (parsed-smile-seq reader key-fn nil))
-	([^BufferedReader reader key-fn array-coerce-fn]
-	 (when reader
-		 (parsed-seq* (.createParser ^SmileFactory
-																 (or factory/*smile-factory*
-																		 factory/smile-factory)
-																 ^Reader reader)
-									key-fn array-coerce-fn))))
+  The array-coerce-fn is an optional function taking the name of an array field,
+  and returning the collection to be used for array values."
+  ([reader] (parsed-smile-seq reader nil nil))
+  ([reader key-fn] (parsed-smile-seq reader key-fn nil))
+  ([^BufferedReader reader key-fn array-coerce-fn]
+   (when reader
+     (parsed-seq* (.createParser ^SmileFactory
+                                 (or factory/*smile-factory*
+                                     factory/smile-factory)
+                                 ^Reader reader)
+                  key-fn array-coerce-fn))))
 
 ;; aliases for clojure-json users
 (def encode "Alias to generate-string for clojure-json users" generate-string)

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -12,26 +12,33 @@
            (java.io StringWriter StringReader BufferedReader BufferedWriter
                     ByteArrayOutputStream OutputStream Reader Writer)))
 
-(def ^:private default-pretty-print-options
-  {:indentation 2
+(defonce default-pretty-print-options
+  {:indentation "  "
+   :line-break "\n"
    :indent-arrays? false
    :indent-objects? true
    :before-array-values nil
    :after-array-values nil
    :object-field-value-separator nil})
 
-(defn- create-pretty-printer
+(defn create-pretty-printer
   "Returns an instance of CustomPrettyPrinter based on the configuration
   provided as argument"
   [options]
   (let [{:keys [indentation
+                line-break
                 indent-arrays?
                 indent-objects?
                 before-array-values
                 after-array-values
-                object-field-value-separator]} (merge default-pretty-print-options options)]
+                object-field-value-separator]} (merge default-pretty-print-options options)
+        indent-with (condp instance? indentation
+                      String indentation
+                      Long (apply str (repeat indentation " "))
+                      Integer (apply str (repeat indentation " "))
+                      "  ")]
     (-> (new CustomPrettyPrinter)
-        (.setIndentation indentation indent-objects? indent-arrays?)
+        (.setIndentation indent-with line-break indent-objects? indent-arrays?)
         (.setBeforeArrayValues before-array-values)
         (.setAfterArrayValues after-array-values)
         (.setObjectFieldValueSeparator object-field-value-separator))))

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -15,87 +15,86 @@
 										ByteArrayOutputStream OutputStream Reader Writer)))
 
 (def ^:private default-pretty-print-options
-	{:indentation 2
-	 :indent-arrays? false
-	 :indent-objects? true
-	 :before-array-values nil
-	 :after-array-values nil
-	 :object-field-value-separator nil})
+  {:indentation 2
+   :indent-arrays? false
+   :indent-objects? true
+   :before-array-values nil
+   :after-array-values nil
+   :object-field-value-separator nil})
 
 (defn- create-pretty-printer
-	 "Returns an instance of CustomPrettyPrinter based on the configuration
-	 provided as argument"
-	 [options]
-	 (let [{:keys [indentation
-								 indent-arrays?
-								 indent-objects?
-								 before-array-values
-								 after-array-values
-								 object-field-value-separator]} (merge default-pretty-print-options options)]
-		(-> (new CustomPrettyPrinter)
-				(.setIndentation indentation indent-objects? indent-arrays?)
-				(.setBeforeArrayValues before-array-values)
-				(.setAfterArrayValues after-array-values)
-				(.setObjectFieldValueSeparator object-field-value-separator))))
+  "Returns an instance of CustomPrettyPrinter based on the configuration
+  provided as argument"
+  [options]
+  (let [{:keys [indentation
+                indent-arrays?
+                indent-objects?
+                before-array-values
+                after-array-values
+                object-field-value-separator]} (merge default-pretty-print-options options)]
+    (-> (new CustomPrettyPrinter)
+            (.setIndentation indentation indent-objects? indent-arrays?)
+            (.setBeforeArrayValues before-array-values)
+            (.setAfterArrayValues after-array-values)
+            (.setObjectFieldValueSeparator object-field-value-separator))))
 
 ;; Generators
 (defn ^String generate-string
-	"Returns a JSON-encoding String for the given Clojure object. Takes an
-	optional date format string that Date objects will be encoded with.
+  "Returns a JSON-encoding String for the given Clojure object. Takes an
+  optional date format string that Date objects will be encoded with.
 
-	The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-	([obj]
-	 (generate-string obj nil))
-	([obj opt-map]
-	 (let [sw (StringWriter.)
-				 print-pretty (:pretty opt-map)
-				 generator (.createGenerator
-										^JsonFactory (or factory/*json-factory*
-																		 factory/json-factory)
-										^Writer sw)]
-		 (when print-pretty
-				(if (= print-pretty true)
-					; pretty = true uses default pretty printer
-					(.useDefaultPrettyPrinter generator)
-					; else we construct a custom pretty printer
-					(.setPrettyPrinter generator (create-pretty-printer print-pretty))))
-		 (when (:escape-non-ascii opt-map)
-			 (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
-		 (gen/generate generator obj
-									 (or (:date-format opt-map) factory/default-date-format)
-									 (:ex opt-map)
-									 (:key-fn opt-map))
-		 (.flush generator)
-		 (.toString sw))))
+  The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
+  ([obj]
+   (generate-string obj nil))
+  ([obj opt-map]
+   (let [sw (StringWriter.)
+         print-pretty (:pretty opt-map)
+         generator (.createGenerator
+                    ^JsonFactory (or factory/*json-factory*
+                                     factory/json-factory)
+                    ^Writer sw)]
+    (when print-pretty
+      (if (= print-pretty true)
+        ; pretty = true uses default pretty printer
+        (.useDefaultPrettyPrinter generator)
+        ; else we construct a custom pretty printer
+        (.setPrettyPrinter generator (create-pretty-printer print-pretty))))
+    (when (:escape-non-ascii opt-map)
+      (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
+    (gen/generate generator obj
+                  (or (:date-format opt-map) factory/default-date-format)
+                  (:ex opt-map)
+                  (:key-fn opt-map))
+    (.flush generator)
+    (.toString sw))))
 
 (defn ^BufferedWriter generate-stream
-	"Returns a BufferedWriter for the given Clojure object with the JSON-encoded
-	data written to the writer. Takes an optional date format string that Date
-	objects will be encoded with.
+  "Returns a BufferedWriter for the given Clojure object with the JSON-encoded
+  data written to the writer. Takes an optional date format string that Date
+  objects will be encoded with.
 
-	The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-	([obj ^BufferedWriter writer]
-	 (generate-stream obj writer nil))
-	([obj ^BufferedWriter writer opt-map]
-	 (let [generator (.createGenerator
-										^JsonFactory (or factory/*json-factory*
-																		 factory/json-factory)
-										^Writer writer)
-				 print-pretty (:pretty opt-map)]
-		 (when print-pretty
-			 (if (= print-pretty true)
-				 ; pretty = true uses default pretty printer
-				 (.useDefaultPrettyPrinter generator)
-				 ; else we construct a custom pretty printer
-				 (.setPrettyPrinter generator (create-pretty-printer print-pretty))))
-		 (when (:escape-non-ascii opt-map)
-			 (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
-		 (gen/generate generator obj (or (:date-format opt-map)
-																		 factory/default-date-format)
-									 (:ex opt-map)
-									 (:key-fn opt-map))
-		 (.flush generator)
-		 writer)))
+  The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
+  ([obj ^BufferedWriter writer]
+   (generate-stream obj writer nil))
+  ([obj ^BufferedWriter writer opt-map]
+   (let [generator (.createGenerator
+                    ^JsonFactory (or factory/*json-factory*
+                                                     factory/json-factory)
+                    ^Writer writer)
+         print-pretty (:pretty opt-map)]
+     (when print-pretty
+       (if (= print-pretty true)
+           ; pretty = true uses default pretty printer
+           (.useDefaultPrettyPrinter generator)
+           ; else we construct a custom pretty printer
+           (.setPrettyPrinter generator (create-pretty-printer print-pretty))))
+     (when (:escape-non-ascii opt-map)
+       (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
+     (gen/generate generator obj (or (:date-format opt-map) factory/default-date-format)
+                                     (:ex opt-map)
+                                     (:key-fn opt-map))
+     (.flush generator)
+     writer)))
 
 (defn create-generator [writer]
 	"Returns JsonGenerator for given writer."

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -25,13 +25,14 @@
   "Returns an instance of CustomPrettyPrinter based on the configuration
   provided as argument"
   [options]
-  (let [{:keys [indentation
-                line-break
-                indent-arrays?
-                indent-objects?
-                before-array-values
-                after-array-values
-                object-field-value-separator]} (merge default-pretty-print-options options)
+  (let [effective-opts (merge default-pretty-print-options options)
+        indentation (:indentation effective-opts)
+        line-break (:line-break effective-opts)
+        indent-arrays? (:indent-arrays? effective-opts)
+        indent-objects? (:indent-objects? effective-opts)
+        before-array-values (:before-array-values effective-opts)
+        after-array-values (:after-array-values effective-opts)
+        object-field-value-separator (:object-field-value-separator effective-opts)
         indent-with (condp instance? indentation
                       String indentation
                       Long (apply str (repeat indentation " "))

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -5,7 +5,7 @@
             [cheshire.generate-seq :as gen-seq]
             [cheshire.parse :as parse])
   (:import (com.fasterxml.jackson.core JsonParser JsonFactory
-                                       JsonGenerator
+                                       JsonGenerator PrettyPrinter
                                        JsonGenerator$Feature)
            (com.fasterxml.jackson.dataformat.smile SmileFactory)
            (cheshire.prettyprint CustomPrettyPrinter)
@@ -51,10 +51,14 @@
                                      factory/json-factory)
                     ^Writer sw)
          print-pretty (:pretty opt-map)]
-     (when (= true print-pretty)
-       (.useDefaultPrettyPrinter generator))
-     (when (map? print-pretty)
-       (.setPrettyPrinter generator (create-pretty-printer print-pretty)))
+     (condp instance? print-pretty
+       Boolean
+         (.useDefaultPrettyPrinter generator)
+       clojure.lang.IPersistentMap
+         (.setPrettyPrinter generator (create-pretty-printer print-pretty))
+       PrettyPrinter
+         (.setPrettyPrinter generator print-pretty)
+       nil)
      (when (:escape-non-ascii opt-map)
        (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
      (gen/generate generator obj

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -51,10 +51,10 @@
                                      factory/json-factory)
                     ^Writer sw)
          print-pretty (:pretty opt-map)]
-     (when print-pretty
-       (if (= true print-pretty)
-         (.useDefaultPrettyPrinter generator)
-         (.setPrettyPrinter generator (create-pretty-printer print-pretty))))
+     (when (= true print-pretty)
+       (.useDefaultPrettyPrinter generator))
+     (when (map? print-pretty)
+       (.setPrettyPrinter generator (create-pretty-printer print-pretty)))
      (when (:escape-non-ascii opt-map)
        (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
      (gen/generate generator obj
@@ -78,10 +78,10 @@
                                      factory/json-factory)
                     ^Writer writer)
          print-pretty (:pretty opt-map)]
-     (when print-pretty
-       (if (= true print-pretty)
-         (.useDefaultPrettyPrinter generator)
-         (.setPrettyPrinter generator (create-pretty-printer print-pretty))))
+     (when (= true print-pretty)
+       (.useDefaultPrettyPrinter generator))
+     (when (map? print-pretty)
+       (.setPrettyPrinter generator (create-pretty-printer print-pretty)))
      (when (:escape-non-ascii opt-map)
        (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
      (gen/generate generator obj (or (:date-format opt-map)

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -82,10 +82,14 @@
                                      factory/json-factory)
                     ^Writer writer)
          print-pretty (:pretty opt-map)]
-     (when (= true print-pretty)
-       (.useDefaultPrettyPrinter generator))
-     (when (map? print-pretty)
-       (.setPrettyPrinter generator (create-pretty-printer print-pretty)))
+     (condp instance? print-pretty
+       Boolean
+         (.useDefaultPrettyPrinter generator)
+       clojure.lang.IPersistentMap
+         (.setPrettyPrinter generator (create-pretty-printer print-pretty))
+       PrettyPrinter
+         (.setPrettyPrinter generator print-pretty)
+       nil)
      (when (:escape-non-ascii opt-map)
        (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
      (gen/generate generator obj (or (:date-format opt-map)

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -1,347 +1,352 @@
 (ns cheshire.core
-  "Main encoding and decoding namespace."
-  (:require [cheshire.factory :as factory]
-            [cheshire.generate :as gen]
-            [cheshire.generate-seq :as gen-seq]
-            [cheshire.parse :as parse])
-  (:import (com.fasterxml.jackson.core JsonParser JsonFactory
-                                       JsonGenerator
-                                       PrettyPrinter
-                                       JsonGenerator$Feature)
-           (com.fasterxml.jackson.dataformat.smile SmileFactory)
-           (java.io StringWriter StringReader BufferedReader BufferedWriter
-                    ByteArrayOutputStream OutputStream Reader Writer)))
+	"Main encoding and decoding namespace."
+	(:require [cheshire.factory :as factory]
+						[cheshire.generate :as gen]
+						[cheshire.generate-seq :as gen-seq]
+						[cheshire.parse :as parse])
+	(:import (com.fasterxml.jackson.core JsonParser
+                                       JsonFactory
+																			 JsonGenerator
+																			 PrettyPrinter
+																			 JsonGenerator$Feature)
+					 (com.fasterxml.jackson.dataformat.smile SmileFactory)
+					 (java.io StringWriter StringReader BufferedReader BufferedWriter
+										ByteArrayOutputStream OutputStream Reader Writer)))
 
-(defn- indent
-  [level indentation]
-  (let [tab (apply str (repeat indentation " "))
-        tabs (apply str (repeat level tab))]
-    (str "\n" tabs)))
+(defn- indent-with-spaces
+	[indentation level]
+	(let [space (apply str (repeat indentation " "))
+				spaces (apply str (repeat level space))]
+		(str "\n" spaces)))
 
-(defn ^PrettyPrinter generate-pretty-printer
-  "Generates a pretty printer instance from
-  a map with flags"
-  [options]
-  (let [defaults {:indentation 2
-                  :indent-arrays? true
-                  :array-value-separator ", " ; used when not indent-arrays?
-                  :object-key-value-separator " : "}
-        level (atom 0)
-        {:keys [indentation
-                indent-arrays?
-                array-value-separator
-                object-key-value-separator]} (merge defaults options)]
-    (reify PrettyPrinter
-      (writeStartArray [_ gen]
-        (.writeRaw gen "[")
-        (swap! level inc))
-      (beforeArrayValues [_ gen]
-        (if indent-arrays?
-          (.writeRaw gen (indent @level indentation))
-          (.writeRaw gen "")))
-      (writeArrayValueSeparator [_ gen]
-        (if indent-arrays?
-          (.writeRaw gen (str "," (indent @level indentation)))
-          (.writeRaw gen array-value-separator)))
-      (writeEndArray [_ gen _]
-        (swap! level dec)
-        (if indent-arrays?
-          (.writeRaw gen (str (indent @level indentation) "]"))
-          (.writeRaw gen "]")))
+(defn- indent-fn
+	[indentation]
+	(partial indent-with-spaces indentation))
 
-      (writeStartObject [_ gen]
-        (.writeRaw gen "{")
-        (swap! level inc)
-        (.writeRaw gen (indent @level indentation)))
-      (beforeObjectEntries [_ gen]
-        (.writeRaw gen ""))
-      (writeObjectFieldValueSeparator [_ gen]
-        (.writeRaw gen object-key-value-separator))
-      (writeObjectEntrySeparator [_ gen]
-        (.writeRaw gen (str "," (indent @level indentation))))
-      (writeEndObject [_ gen _]
-        (swap! level dec)
-        (.writeRaw gen (str (indent @level indentation) "}")))
+(defn- ^PrettyPrinter generate-pretty-printer
+	"Generates a pretty printer instance from
+	a map with flags"
+	[options]
+	(let [defaults {:indentation 2
+									:indent-arrays? true
+									:array-value-separator ", " ; used when not indent-arrays?
+									:object-key-value-separator " : "}
+				level (atom 0)
+				{:keys [indentation
+								indent-arrays?
+								array-value-separator
+								object-key-value-separator]} (merge defaults options)
+				indent (memoize (indent-fn indentation))]
+		(reify PrettyPrinter
+			(writeStartArray [_ gen]
+				(.writeRaw gen "[")
+				(swap! level inc))
+			(beforeArrayValues [_ gen]
+				(if indent-arrays?
+					(.writeRaw gen (indent @level))))
+			(writeArrayValueSeparator [_ gen]
+				(if indent-arrays?
+					(.writeRaw gen (str "," (indent @level)))
+					(.writeRaw gen array-value-separator)))
+			(writeEndArray [_ gen _]
+				(swap! level dec)
+				(if indent-arrays?
+					(.writeRaw gen (str (indent @level) "]"))
+					(.writeRaw gen "]")))
 
-      (writeRootValueSeparator [_ jg]
-        (.writeRaw jg "")))))
+			(writeStartObject [_ gen]
+				(.writeRaw gen "{")
+				(swap! level inc)
+				(.writeRaw gen (indent @level)))
+			(beforeObjectEntries [_ gen]
+				(.writeRaw gen ""))
+			(writeObjectFieldValueSeparator [_ gen]
+				(.writeRaw gen object-key-value-separator))
+			(writeObjectEntrySeparator [_ gen]
+				(.writeRaw gen (str "," (indent @level))))
+			(writeEndObject [_ gen _]
+				(swap! level dec)
+				(.writeRaw gen (str (indent @level) "}")))
+
+			(writeRootValueSeparator [_ jg]
+				(.writeRaw jg "")))))
 
 ;; Generators
 (defn ^String generate-string
-  "Returns a JSON-encoding String for the given Clojure object. Takes an
-  optional date format string that Date objects will be encoded with.
+	"Returns a JSON-encoding String for the given Clojure object. Takes an
+	optional date format string that Date objects will be encoded with.
 
-  The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-  ([obj]
-   (generate-string obj nil))
-  ([obj opt-map]
-   (let [sw (StringWriter.)
-         print-pretty (:pretty opt-map)
-         generator (.createGenerator
-                    ^JsonFactory (or factory/*json-factory*
-                                     factory/json-factory)
-                    ^Writer sw)]
-     (when print-pretty
-        (if (= print-pretty true)
-          ; pretty = true uses default pretty printer
-          (.useDefaultPrettyPrinter generator)
-          ; else we construct a custom pretty printer
-          (.setPrettyPrinter generator
-                             (generate-pretty-printer (if (map? print-pretty)
-                                                          print-pretty
-                                                          {})))))
-     (when (:escape-non-ascii opt-map)
-       (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
-     (gen/generate generator obj
-                   (or (:date-format opt-map) factory/default-date-format)
-                   (:ex opt-map)
-                   (:key-fn opt-map))
-     (.flush generator)
-     (.toString sw))))
+	The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
+	([obj]
+	 (generate-string obj nil))
+	([obj opt-map]
+	 (let [sw (StringWriter.)
+				 print-pretty (:pretty opt-map)
+				 generator (.createGenerator
+										^JsonFactory (or factory/*json-factory*
+																		 factory/json-factory)
+										^Writer sw)]
+		 (when print-pretty
+				(if (= print-pretty true)
+					; pretty = true uses default pretty printer
+					(.useDefaultPrettyPrinter generator)
+					; else we construct a custom pretty printer
+					(.setPrettyPrinter generator
+														 (generate-pretty-printer (if (map? print-pretty)
+																													print-pretty
+																													{})))))
+		 (when (:escape-non-ascii opt-map)
+			 (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
+		 (gen/generate generator obj
+									 (or (:date-format opt-map) factory/default-date-format)
+									 (:ex opt-map)
+									 (:key-fn opt-map))
+		 (.flush generator)
+		 (.toString sw))))
 
 (defn ^BufferedWriter generate-stream
-  "Returns a BufferedWriter for the given Clojure object with the JSON-encoded
-  data written to the writer. Takes an optional date format string that Date
-  objects will be encoded with.
+	"Returns a BufferedWriter for the given Clojure object with the JSON-encoded
+	data written to the writer. Takes an optional date format string that Date
+	objects will be encoded with.
 
-  The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-  ([obj ^BufferedWriter writer]
-   (generate-stream obj writer nil))
-  ([obj ^BufferedWriter writer opt-map]
-   (let [generator (.createGenerator
-                    ^JsonFactory (or factory/*json-factory*
-                                     factory/json-factory)
-                    ^Writer writer)]
-     (when (:pretty opt-map)
-       (.useDefaultPrettyPrinter generator))
-     (when (:escape-non-ascii opt-map)
-       (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
-     (gen/generate generator obj (or (:date-format opt-map)
-                                     factory/default-date-format)
-                   (:ex opt-map)
-                   (:key-fn opt-map))
-     (.flush generator)
-     writer)))
+	The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
+	([obj ^BufferedWriter writer]
+	 (generate-stream obj writer nil))
+	([obj ^BufferedWriter writer opt-map]
+	 (let [generator (.createGenerator
+										^JsonFactory (or factory/*json-factory*
+																		 factory/json-factory)
+										^Writer writer)]
+		 (when (:pretty opt-map)
+			 (.useDefaultPrettyPrinter generator))
+		 (when (:escape-non-ascii opt-map)
+			 (.enable generator JsonGenerator$Feature/ESCAPE_NON_ASCII))
+		 (gen/generate generator obj (or (:date-format opt-map)
+																		 factory/default-date-format)
+									 (:ex opt-map)
+									 (:key-fn opt-map))
+		 (.flush generator)
+		 writer)))
 
 (defn create-generator [writer]
-  "Returns JsonGenerator for given writer."
-  (.createGenerator
-   ^JsonFactory (or factory/*json-factory*
-                    factory/json-factory)
-   ^Writer writer))
+	"Returns JsonGenerator for given writer."
+	(.createGenerator
+	 ^JsonFactory (or factory/*json-factory*
+										factory/json-factory)
+	 ^Writer writer))
 
 (def ^:dynamic ^JsonGenerator *generator*)
 (def ^:dynamic *opt-map*)
 
 (defmacro with-writer [[writer opt-map] & body]
-  "Start writing for series objects using the same json generator.
-   Takes writer and options map as arguments.
-   Expects its body as sequence of write calls.
-   Returns a given writer."
-  `(let [c-wr# ~writer]
-     (binding [*generator* (create-generator c-wr#)
-               *opt-map* ~opt-map]
-       ~@body
-       (.flush *generator*)
-       c-wr#)))
+	"Start writing for series objects using the same json generator.
+	 Takes writer and options map as arguments.
+	 Expects its body as sequence of write calls.
+	 Returns a given writer."
+	`(let [c-wr# ~writer]
+		 (binding [*generator* (create-generator c-wr#)
+							 *opt-map* ~opt-map]
+			 ~@body
+			 (.flush *generator*)
+			 c-wr#)))
 
 (defn write
-  "Write given Clojure object as a piece of data within with-writer.
-  List of wholeness acceptable values:
-  - no value - the same as :all
-  - :all - write object in a regular way with start and end borders
-  - :start - write object with start border only
-  - :start-inner - write object and its inner object with start border only
-  - :end - write object with end border only."
-  ([obj] (write obj nil))
-  ([obj wholeness]
-   (gen-seq/generate *generator* obj (or (:date-format *opt-map*)
-                                         factory/default-date-format)
-                     (:ex *opt-map*)
-                     (:key-fn *opt-map*)
-                     :wholeness wholeness)))
+	"Write given Clojure object as a piece of data within with-writer.
+	List of wholeness acceptable values:
+	- no value - the same as :all
+	- :all - write object in a regular way with start and end borders
+	- :start - write object with start border only
+	- :start-inner - write object and its inner object with start border only
+	- :end - write object with end border only."
+	([obj] (write obj nil))
+	([obj wholeness]
+	 (gen-seq/generate *generator* obj (or (:date-format *opt-map*)
+																				 factory/default-date-format)
+										 (:ex *opt-map*)
+										 (:key-fn *opt-map*)
+										 :wholeness wholeness)))
 
 (defn generate-smile
-  "Returns a SMILE-encoded byte-array for the given Clojure object.
-  Takes an optional date format string that Date objects will be encoded with.
+	"Returns a SMILE-encoded byte-array for the given Clojure object.
+	Takes an optional date format string that Date objects will be encoded with.
 
-  The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-  ([obj]
-   (generate-smile obj nil))
-  ([obj opt-map]
-   (let [baos (ByteArrayOutputStream.)
-         generator (.createGenerator ^SmileFactory
-                                     (or factory/*smile-factory*
-                                         factory/smile-factory)
-                                     ^OutputStream baos)]
-     (gen/generate generator obj (or (:date-format opt-map)
-                                     factory/default-date-format)
-                   (:ex opt-map)
-                   (:key-fn opt-map))
-     (.flush generator)
-     (.toByteArray baos))))
+	The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
+	([obj]
+	 (generate-smile obj nil))
+	([obj opt-map]
+	 (let [baos (ByteArrayOutputStream.)
+				 generator (.createGenerator ^SmileFactory
+																		 (or factory/*smile-factory*
+																				 factory/smile-factory)
+																		 ^OutputStream baos)]
+		 (gen/generate generator obj (or (:date-format opt-map)
+																		 factory/default-date-format)
+									 (:ex opt-map)
+									 (:key-fn opt-map))
+		 (.flush generator)
+		 (.toByteArray baos))))
 
 (defn generate-cbor
-  "Returns a CBOR-encoded byte-array for the given Clojure object.
-  Takes an optional date format string that Date objects will be encoded with.
+	"Returns a CBOR-encoded byte-array for the given Clojure object.
+	Takes an optional date format string that Date objects will be encoded with.
 
-  The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-  ([obj]
-   (generate-cbor obj nil))
-  ([obj opt-map]
-   (let [baos (ByteArrayOutputStream.)
-         generator (.createGenerator ^CBORFactory
-                                     (or factory/*cbor-factory*
-                                         factory/cbor-factory)
-                                     ^OutputStream baos)]
-     (gen/generate generator obj (or (:date-format opt-map)
-                                     factory/default-date-format)
-                   (:ex opt-map)
-                   (:key-fn opt-map))
-     (.flush generator)
-     (.toByteArray baos))))
+	The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
+	([obj]
+	 (generate-cbor obj nil))
+	([obj opt-map]
+	 (let [baos (ByteArrayOutputStream.)
+				 generator (.createGenerator ^CBORFactory
+																		 (or factory/*cbor-factory*
+																				 factory/cbor-factory)
+																		 ^OutputStream baos)]
+		 (gen/generate generator obj (or (:date-format opt-map)
+																		 factory/default-date-format)
+									 (:ex opt-map)
+									 (:key-fn opt-map))
+		 (.flush generator)
+		 (.toByteArray baos))))
 
 ;; Parsers
 (defn parse-string
-  "Returns the Clojure object corresponding to the given JSON-encoded string.
-  An optional key-fn argument can be either true (to coerce keys to keywords),
-  false to leave them as strings, or a function to provide custom coercion.
+	"Returns the Clojure object corresponding to the given JSON-encoded string.
+	An optional key-fn argument can be either true (to coerce keys to keywords),
+	false to leave them as strings, or a function to provide custom coercion.
 
-  The array-coerce-fn is an optional function taking the name of an array field,
-  and returning the collection to be used for array values.
+	The array-coerce-fn is an optional function taking the name of an array field,
+	and returning the collection to be used for array values.
 
-  If the top-level object is an array, it will be parsed lazily (use
-  `parse-strict' if strict parsing is required for top-level arrays."
-  ([string] (parse-string string nil nil))
-  ([string key-fn] (parse-string string key-fn nil))
-  ([^String string key-fn array-coerce-fn]
-   (when string
-     (parse/parse
-      (.createParser ^JsonFactory (or factory/*json-factory*
-                                      factory/json-factory)
-                     ^Reader (StringReader. string))
-      key-fn nil array-coerce-fn))))
+	If the top-level object is an array, it will be parsed lazily (use
+	`parse-strict' if strict parsing is required for top-level arrays."
+	([string] (parse-string string nil nil))
+	([string key-fn] (parse-string string key-fn nil))
+	([^String string key-fn array-coerce-fn]
+	 (when string
+		 (parse/parse
+			(.createParser ^JsonFactory (or factory/*json-factory*
+																			factory/json-factory)
+										 ^Reader (StringReader. string))
+			key-fn nil array-coerce-fn))))
 
 ;; Parsing strictly
 (defn parse-string-strict
-  "Returns the Clojure object corresponding to the given JSON-encoded string.
-  An optional key-fn argument can be either true (to coerce keys to keywords),
-  false to leave them as strings, or a function to provide custom coercion.
+	"Returns the Clojure object corresponding to the given JSON-encoded string.
+	An optional key-fn argument can be either true (to coerce keys to keywords),
+	false to leave them as strings, or a function to provide custom coercion.
 
-  The array-coerce-fn is an optional function taking the name of an array field,
-  and returning the collection to be used for array values.
+	The array-coerce-fn is an optional function taking the name of an array field,
+	and returning the collection to be used for array values.
 
-  Does not lazily parse top-level arrays."
-  ([string] (parse-string-strict string nil nil))
-  ([string key-fn] (parse-string-strict string key-fn nil))
-  ([^String string key-fn array-coerce-fn]
-   (when string
-     (parse/parse-strict
-      (.createParser ^JsonFactory (or factory/*json-factory*
-                                      factory/json-factory)
-                     ^Writer (StringReader. string))
-      key-fn nil array-coerce-fn))))
+	Does not lazily parse top-level arrays."
+	([string] (parse-string-strict string nil nil))
+	([string key-fn] (parse-string-strict string key-fn nil))
+	([^String string key-fn array-coerce-fn]
+	 (when string
+		 (parse/parse-strict
+			(.createParser ^JsonFactory (or factory/*json-factory*
+																			factory/json-factory)
+										 ^Writer (StringReader. string))
+			key-fn nil array-coerce-fn))))
 
 (defn parse-stream
-  "Returns the Clojure object corresponding to the given reader, reader must
-  implement BufferedReader. An optional key-fn argument can be either true (to
-  coerce keys to keywords),false to leave them as strings, or a function to
-  provide custom coercion.
+	"Returns the Clojure object corresponding to the given reader, reader must
+	implement BufferedReader. An optional key-fn argument can be either true (to
+	coerce keys to keywords),false to leave them as strings, or a function to
+	provide custom coercion.
 
-  The array-coerce-fn is an optional function taking the name of an array field,
-  and returning the collection to be used for array values.
+	The array-coerce-fn is an optional function taking the name of an array field,
+	and returning the collection to be used for array values.
 
-  If the top-level object is an array, it will be parsed lazily (use
-  `parse-strict' if strict parsing is required for top-level arrays.
+	If the top-level object is an array, it will be parsed lazily (use
+	`parse-strict' if strict parsing is required for top-level arrays.
 
-  If multiple objects (enclosed in a top-level `{}' need to be parsed lazily,
-  see parsed-seq."
-  ([rdr] (parse-stream rdr nil nil))
-  ([rdr key-fn] (parse-stream rdr key-fn nil))
-  ([^BufferedReader rdr key-fn array-coerce-fn]
-   (when rdr
-     (parse/parse
-      (.createParser ^JsonFactory (or factory/*json-factory*
-                                      factory/json-factory)
-                     ^Reader rdr)
-      key-fn nil array-coerce-fn))))
+	If multiple objects (enclosed in a top-level `{}' need to be parsed lazily,
+	see parsed-seq."
+	([rdr] (parse-stream rdr nil nil))
+	([rdr key-fn] (parse-stream rdr key-fn nil))
+	([^BufferedReader rdr key-fn array-coerce-fn]
+	 (when rdr
+		 (parse/parse
+			(.createParser ^JsonFactory (or factory/*json-factory*
+																			factory/json-factory)
+										 ^Reader rdr)
+			key-fn nil array-coerce-fn))))
 
 (defn parse-smile
-  "Returns the Clojure object corresponding to the given SMILE-encoded bytes.
-  An optional key-fn argument can be either true (to coerce keys to keywords),
-  false to leave them as strings, or a function to provide custom coercion.
+	"Returns the Clojure object corresponding to the given SMILE-encoded bytes.
+	An optional key-fn argument can be either true (to coerce keys to keywords),
+	false to leave them as strings, or a function to provide custom coercion.
 
-  The array-coerce-fn is an optional function taking the name of an array field,
-  and returning the collection to be used for array values."
-  ([bytes] (parse-smile bytes nil nil))
-  ([bytes key-fn] (parse-smile bytes key-fn nil))
-  ([^bytes bytes key-fn array-coerce-fn]
-   (when bytes
-     (parse/parse
-      (.createParser ^SmileFactory (or factory/*smile-factory*
-                                       factory/smile-factory) bytes)
-      key-fn nil array-coerce-fn))))
+	The array-coerce-fn is an optional function taking the name of an array field,
+	and returning the collection to be used for array values."
+	([bytes] (parse-smile bytes nil nil))
+	([bytes key-fn] (parse-smile bytes key-fn nil))
+	([^bytes bytes key-fn array-coerce-fn]
+	 (when bytes
+		 (parse/parse
+			(.createParser ^SmileFactory (or factory/*smile-factory*
+																			 factory/smile-factory) bytes)
+			key-fn nil array-coerce-fn))))
 
 (defn parse-cbor
-  "Returns the Clojure object corresponding to the given CBOR-encoded bytes.
-  An optional key-fn argument can be either true (to coerce keys to keywords),
-  false to leave them as strings, or a function to provide custom coercion.
+	"Returns the Clojure object corresponding to the given CBOR-encoded bytes.
+	An optional key-fn argument can be either true (to coerce keys to keywords),
+	false to leave them as strings, or a function to provide custom coercion.
 
-  The array-coerce-fn is an optional function taking the name of an array field,
-  and returning the collection to be used for array values."
-  ([bytes] (parse-cbor bytes nil nil))
-  ([bytes key-fn] (parse-cbor bytes key-fn nil))
-  ([^bytes bytes key-fn array-coerce-fn]
-   (when bytes
-     (parse/parse
-      (.createParser ^CBORFactory (or factory/*cbor-factory*
-                                      factory/cbor-factory) bytes)
-      key-fn nil array-coerce-fn))))
+	The array-coerce-fn is an optional function taking the name of an array field,
+	and returning the collection to be used for array values."
+	([bytes] (parse-cbor bytes nil nil))
+	([bytes key-fn] (parse-cbor bytes key-fn nil))
+	([^bytes bytes key-fn array-coerce-fn]
+	 (when bytes
+		 (parse/parse
+			(.createParser ^CBORFactory (or factory/*cbor-factory*
+																			factory/cbor-factory) bytes)
+			key-fn nil array-coerce-fn))))
 
 (def ^{:doc "Object used to determine end of lazy parsing attempt."}
-  eof (Object.))
+	eof (Object.))
 
 ;; Lazy parsers
 (defn- parsed-seq*
-  "Internal lazy-seq parser"
-  [^JsonParser parser key-fn array-coerce-fn]
-  (lazy-seq
-   (let [elem (parse/parse-strict parser key-fn eof array-coerce-fn)]
-     (when-not (identical? elem eof)
-       (cons elem (parsed-seq* parser key-fn array-coerce-fn))))))
+	"Internal lazy-seq parser"
+	[^JsonParser parser key-fn array-coerce-fn]
+	(lazy-seq
+	 (let [elem (parse/parse-strict parser key-fn eof array-coerce-fn)]
+		 (when-not (identical? elem eof)
+			 (cons elem (parsed-seq* parser key-fn array-coerce-fn))))))
 
 (defn parsed-seq
-  "Returns a lazy seq of Clojure objects corresponding to the JSON read from
-  the given reader. The seq continues until the end of the reader is reached.
+	"Returns a lazy seq of Clojure objects corresponding to the JSON read from
+	the given reader. The seq continues until the end of the reader is reached.
 
-  The array-coerce-fn is an optional function taking the name of an array field,
-  and returning the collection to be used for array values.
-  If non-laziness is needed, see parse-stream."
-  ([reader] (parsed-seq reader nil nil))
-  ([reader key-fn] (parsed-seq reader key-fn nil))
-  ([^BufferedReader reader key-fn array-coerce-fn]
-   (when reader
-     (parsed-seq* (.createParser ^JsonFactory
-                                 (or factory/*json-factory*
-                                     factory/json-factory)
-                                 ^Reader reader)
-                  key-fn array-coerce-fn))))
+	The array-coerce-fn is an optional function taking the name of an array field,
+	and returning the collection to be used for array values.
+	If non-laziness is needed, see parse-stream."
+	([reader] (parsed-seq reader nil nil))
+	([reader key-fn] (parsed-seq reader key-fn nil))
+	([^BufferedReader reader key-fn array-coerce-fn]
+	 (when reader
+		 (parsed-seq* (.createParser ^JsonFactory
+																 (or factory/*json-factory*
+																		 factory/json-factory)
+																 ^Reader reader)
+									key-fn array-coerce-fn))))
 
 (defn parsed-smile-seq
-  "Returns a lazy seq of Clojure objects corresponding to the SMILE read from
-  the given reader. The seq continues until the end of the reader is reached.
+	"Returns a lazy seq of Clojure objects corresponding to the SMILE read from
+	the given reader. The seq continues until the end of the reader is reached.
 
-  The array-coerce-fn is an optional function taking the name of an array field,
-  and returning the collection to be used for array values."
-  ([reader] (parsed-smile-seq reader nil nil))
-  ([reader key-fn] (parsed-smile-seq reader key-fn nil))
-  ([^BufferedReader reader key-fn array-coerce-fn]
-   (when reader
-     (parsed-seq* (.createParser ^SmileFactory
-                                 (or factory/*smile-factory*
-                                     factory/smile-factory)
-                                 ^Reader reader)
-                  key-fn array-coerce-fn))))
+	The array-coerce-fn is an optional function taking the name of an array field,
+	and returning the collection to be used for array values."
+	([reader] (parsed-smile-seq reader nil nil))
+	([reader key-fn] (parsed-smile-seq reader key-fn nil))
+	([^BufferedReader reader key-fn array-coerce-fn]
+	 (when reader
+		 (parsed-seq* (.createParser ^SmileFactory
+																 (or factory/*smile-factory*
+																		 factory/smile-factory)
+																 ^Reader reader)
+									key-fn array-coerce-fn))))
 
 ;; aliases for clojure-json users
 (def encode "Alias to generate-string for clojure-json users" generate-string)

--- a/src/java/cheshire/prettyprint/CustomPrettyPrinter.java
+++ b/src/java/cheshire/prettyprint/CustomPrettyPrinter.java
@@ -6,20 +6,6 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 
 import java.io.IOException;
 
-class DynamicIndenter extends DefaultIndenter {
-    public static String repeat(String whitespace, int times) {
-        String indentWith = "";
-        while(--times >= 0) {
-            indentWith += whitespace;
-        }
-        return indentWith;
-    }
-
-    public DynamicIndenter(int indentation) {
-        super(DynamicIndenter.repeat(" ", indentation), "\n");
-    }
-}
-
 public class CustomPrettyPrinter extends DefaultPrettyPrinter {
     private String _beforeArrayValues;
     private String _afterArrayValues;
@@ -56,8 +42,8 @@ public class CustomPrettyPrinter extends DefaultPrettyPrinter {
         }
     }
 
-    public CustomPrettyPrinter setIndentation(int indentation, boolean indentObjects, boolean indentArrays) {
-        Indenter indenter = new DynamicIndenter(indentation);
+    public CustomPrettyPrinter setIndentation(String indentation, String lineBreak, boolean indentObjects, boolean indentArrays) {
+        Indenter indenter = new DefaultIndenter(indentation, lineBreak);
         if (indentArrays) {
             this.indentArraysWith(indenter);
         }

--- a/src/java/cheshire/prettyprint/CustomPrettyPrinter.java
+++ b/src/java/cheshire/prettyprint/CustomPrettyPrinter.java
@@ -1,0 +1,87 @@
+package cheshire.prettyprint;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+
+import java.io.IOException;
+
+class DynamicIndenter extends DefaultIndenter {
+    public DynamicIndenter(int indentation) {
+        super(new String(new char[indentation]).replace("\0", " "), "\n");
+    }
+    public DynamicIndenter(int indentation, String newline) {
+        super(new String(new char[indentation]).replace("\0", " "), newline);
+    }
+}
+
+public class CustomPrettyPrinter extends DefaultPrettyPrinter {
+    private Indenter _indenter;
+    private int _indentation = 2;
+    private boolean _indentObjects = true;
+    private boolean _indentArrays = true;
+    private String _beforeArrayValues;
+    private String _afterArrayValues;
+    private String _objectFieldValueSeparator;
+
+    public CustomPrettyPrinter() {
+        super();
+    }
+
+    @Override
+    public void beforeArrayValues(JsonGenerator gen) throws IOException {
+        if (this._beforeArrayValues != null) {
+            gen.writeRaw(this._beforeArrayValues);
+        } else {
+            super.beforeArrayValues(gen);
+        }
+    }
+
+    @Override
+    public void writeEndArray(JsonGenerator gen, int nrOfValues) throws IOException {
+        if (this._afterArrayValues != null) {
+            gen.writeRaw(this._afterArrayValues + "]");
+        } else {
+            super.writeEndArray(gen, nrOfValues);
+        }
+    }
+
+    @Override
+    public void writeObjectFieldValueSeparator(JsonGenerator gen) throws IOException {
+        if (this._objectFieldValueSeparator != null) {
+            gen.writeRaw(this._objectFieldValueSeparator);
+        } else {
+            super.writeObjectFieldValueSeparator(gen);
+        }
+    }
+
+    public CustomPrettyPrinter setIndentation(int indentation, boolean indentObjects, boolean indentArrays) {
+        this._indentation = indentation;
+        this._indentObjects = indentObjects;
+        this._indentArrays = indentArrays;
+        this._indenter = new DynamicIndenter(indentation);
+        if (this._indentArrays) {
+            this.indentArraysWith(this._indenter);
+        }
+        if (this._indentObjects) {
+            this.indentObjectsWith(this._indenter);
+        }
+        return this;
+    }
+
+    public CustomPrettyPrinter setBeforeArrayValues(String beforeArrayValues) {
+        this._beforeArrayValues = beforeArrayValues;
+        return this;
+    }
+
+    public CustomPrettyPrinter setAfterArrayValues(String afterArrayValues) {
+        this._afterArrayValues = afterArrayValues;
+        return this;
+    }
+
+    public CustomPrettyPrinter setObjectFieldValueSeparator(String objectFieldValueSeparator) {
+        this._objectFieldValueSeparator = objectFieldValueSeparator;
+        return this;
+    }
+
+}

--- a/src/java/cheshire/prettyprint/CustomPrettyPrinter.java
+++ b/src/java/cheshire/prettyprint/CustomPrettyPrinter.java
@@ -7,19 +7,20 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import java.io.IOException;
 
 class DynamicIndenter extends DefaultIndenter {
-    public DynamicIndenter(int indentation) {
-        super(new String(new char[indentation]).replace("\0", " "), "\n");
+    public static String repeat(String whitespace, int times) {
+        String indentWith = "";
+        while(--times >= 0) {
+            indentWith += whitespace;
+        }
+        return indentWith;
     }
-    public DynamicIndenter(int indentation, String newline) {
-        super(new String(new char[indentation]).replace("\0", " "), newline);
+
+    public DynamicIndenter(int indentation) {
+        super(DynamicIndenter.repeat(" ", indentation), "\n");
     }
 }
 
 public class CustomPrettyPrinter extends DefaultPrettyPrinter {
-    private Indenter _indenter;
-    private int _indentation = 2;
-    private boolean _indentObjects = true;
-    private boolean _indentArrays = true;
     private String _beforeArrayValues;
     private String _afterArrayValues;
     private String _objectFieldValueSeparator;
@@ -56,15 +57,12 @@ public class CustomPrettyPrinter extends DefaultPrettyPrinter {
     }
 
     public CustomPrettyPrinter setIndentation(int indentation, boolean indentObjects, boolean indentArrays) {
-        this._indentation = indentation;
-        this._indentObjects = indentObjects;
-        this._indentArrays = indentArrays;
-        this._indenter = new DynamicIndenter(indentation);
-        if (this._indentArrays) {
-            this.indentArraysWith(this._indenter);
+        Indenter indenter = new DynamicIndenter(indentation);
+        if (indentArrays) {
+            this.indentArraysWith(indenter);
         }
-        if (this._indentObjects) {
-            this.indentObjectsWith(this._indenter);
+        if (indentObjects) {
+            this.indentObjectsWith(indenter);
         }
         return this;
     }

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -261,12 +261,13 @@
   (let [test-obj (sorted-map :foo 1 :bar {:baz [{:ulu "mulu"} {:moot "foo"} 3]} :quux :blub)
         pretty-str-default (json/encode test-obj {:pretty true})
         pretty-str-custom (json/encode test-obj {:pretty {}})]
-    ; print for easy comparison
-    (println "; default pretty print")
-    (println pretty-str-default)
-    (println "; custom pretty print with default options")
-    (println pretty-str-custom)
-    (is (= pretty-str-default pretty-str-custom))))
+    (is (= pretty-str-default pretty-str-custom))
+    (when-not (= pretty-str-default pretty-str-custom)
+      ; print for easy comparison
+      (println "; default pretty print")
+      (println pretty-str-default)
+      (println "; custom pretty print with default options")
+      (println pretty-str-custom))))
 
 (deftest t-custom-pretty-print-with-non-defaults
   (let [test-obj (sorted-map :foo 1 :bar {:baz [{:ulu "mulu"} {:moot "foo"} 3]} :quux :blub)
@@ -275,24 +276,26 @@
                             :before-array-values ""
                             :after-array-values ""
                             :object-field-value-separator ": "}}
+        expected (str "{\n"
+                      "    \"bar\": {\n"
+                      "        \"baz\": [{\n"
+                      "            \"ulu\": \"mulu\"\n"
+                      "        }, {\n"
+                      "            \"moot\": \"foo\"\n"
+                      "        }, 3]\n"
+                      "    },\n"
+                      "    \"foo\": 1,\n"
+                      "    \"quux\": \"blub\"\n"
+                      "}")
         pretty-str (json/encode test-obj test-opts)]
+
     ; just to be easy on the eyes in case of error
-    (println "; pretty print with options")
-    (println (json/encode test-obj
-                          test-opts))
-    ; actual test
-    (is (= (str "{\n"
-                "    \"bar\": {\n"
-                "        \"baz\": [{\n"
-                "            \"ulu\": \"mulu\"\n"
-                "        }, {\n"
-                "            \"moot\": \"foo\"\n"
-                "        }, 3]\n"
-                "    },\n"
-                "    \"foo\": 1,\n"
-                "    \"quux\": \"blub\"\n"
-                "}")
-            pretty-str))))
+    (when-not (= expected pretty-str)
+      (println "; pretty print with options - actual")
+      (println pretty-str)
+      (println "; pretty print with options - expected")
+      (println expected))
+    (is (= expected pretty-str))))
 
 (deftest t-unicode-escaping
   (is (= "{\"foo\":\"It costs \\u00A3100\"}"

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -252,31 +252,42 @@
          (json/encode (sorted-map :foo 1 :bar [{:baz 2} :quux [1 2 3]])
                       {:pretty true}))))
 
-(deftest t-custom-pretty-print
+(deftest t-custom-pretty-print-with-defaults
   (let [test-obj {:foo 1 :bar {:baz [{:ulu "mulu"} {:moot "foo"} 3]} :quux "blub"}
-        test-opts {:pretty {:indentation 4 :object-key-value-separator ": "}}
+        pretty-str-default (json/encode test-obj {:pretty true})
+        pretty-str-custom (json/encode test-obj {:pretty {}})]
+    ; print for easy comparison
+    (println "; default pretty print")
+    (println pretty-str-default)
+    (println "; custom pretty print with default options")
+    (println pretty-str-custom)
+    (is (= pretty-str-default pretty-str-custom))))
+
+(deftest t-custom-pretty-print-with-non-defaults
+  (let [test-obj {:foo 1 :bar {:baz [{:ulu "mulu"} {:moot "foo"} 3]} :quux "blub"}
+        test-opts {:pretty {:indentation 4
+                            :indent-arrays? false
+                            :before-array-values ""
+                            :after-array-values ""
+                            :object-field-value-separator ": "}}
         pretty-str (json/encode test-obj test-opts)]
     ; just to be easy on the eyes in case of error
     (println "; pretty print with options")
     (println (json/encode test-obj
                           test-opts))
     ; actual test
-  (is (= (str "{\n"
-              "    \"bar\": {\n"
-              "        \"baz\": [\n"
-              "            {\n"
-              "                \"ulu\": \"mulu\"\n"
-              "            },\n"
-              "            {\n"
-              "                \"moot\": \"foo\"\n"
-              "            },\n"
-              "            3\n"
-              "        ]\n"
-              "    },\n"
-              "    \"foo\": 1,\n"
-              "    \"quux\": \"blub\"\n"
-              "}")
-          pretty-str))))
+    (is (= (str "{\n"
+                "    \"bar\": {\n"
+                "        \"baz\": [{\n"
+                "            \"ulu\": \"mulu\"\n"
+                "        }, {\n"
+                "            \"moot\": \"foo\"\n"
+                "        }, 3]\n"
+                "    },\n"
+                "    \"foo\": 1,\n"
+                "    \"quux\": \"blub\"\n"
+                "}")
+            pretty-str))))
 
 (deftest t-unicode-escaping
   (is (= "{\"foo\":\"It costs \\u00A3100\"}"

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -252,6 +252,32 @@
          (json/encode (sorted-map :foo 1 :bar [{:baz 2} :quux [1 2 3]])
                       {:pretty true}))))
 
+(deftest t-custom-pretty-print
+  (let [test-obj {:foo 1 :bar {:baz [{:ulu "mulu"} {:moot "foo"} 3]} :quux "blub"}
+        test-opts {:pretty {:indentation 4 :object-key-value-separator ": "}}
+        pretty-str (json/encode test-obj test-opts)]
+    ; just to be easy on the eyes in case of error
+    (println "; pretty print with options")
+    (println (json/encode test-obj
+                          test-opts))
+    ; actual test
+  (is (= (str "{\n"
+              "    \"bar\": {\n"
+              "        \"baz\": [\n"
+              "            {\n"
+              "                \"ulu\": \"mulu\"\n"
+              "            },\n"
+              "            {\n"
+              "                \"moot\": \"foo\"\n"
+              "            },\n"
+              "            3\n"
+              "        ]\n"
+              "    },\n"
+              "    \"foo\": 1,\n"
+              "    \"quux\": \"blub\"\n"
+              "}")
+          pretty-str))))
+
 (deftest t-unicode-escaping
   (is (= "{\"foo\":\"It costs \\u00A3100\"}"
          (json/encode {:foo "It costs £100"} {:escape-non-ascii true}))))

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -252,6 +252,11 @@
          (json/encode (sorted-map :foo 1 :bar [{:baz 2} :quux [1 2 3]])
                       {:pretty true}))))
 
+(deftest t-pretty-print-illegal-argument
+  ; just expecting this not to throw
+  (json/encode {:foo "bar"}
+               {:pretty []}))
+
 (deftest t-custom-pretty-print-with-defaults
   (let [test-obj (sorted-map :foo 1 :bar {:baz [{:ulu "mulu"} {:moot "foo"} 3]} :quux :blub)
         pretty-str-default (json/encode test-obj {:pretty true})

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -253,7 +253,7 @@
                       {:pretty true}))))
 
 (deftest t-custom-pretty-print-with-defaults
-  (let [test-obj {:foo 1 :bar {:baz [{:ulu "mulu"} {:moot "foo"} 3]} :quux "blub"}
+  (let [test-obj (sorted-map :foo 1 :bar {:baz [{:ulu "mulu"} {:moot "foo"} 3]} :quux :blub)
         pretty-str-default (json/encode test-obj {:pretty true})
         pretty-str-custom (json/encode test-obj {:pretty {}})]
     ; print for easy comparison
@@ -264,7 +264,7 @@
     (is (= pretty-str-default pretty-str-custom))))
 
 (deftest t-custom-pretty-print-with-non-defaults
-  (let [test-obj {:foo 1 :bar {:baz [{:ulu "mulu"} {:moot "foo"} 3]} :quux "blub"}
+  (let [test-obj (sorted-map :foo 1 :bar {:baz [{:ulu "mulu"} {:moot "foo"} 3]} :quux :blub)
         test-opts {:pretty {:indentation 4
                             :indent-arrays? false
                             :before-array-values ""

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -255,7 +255,9 @@
 (deftest t-pretty-print-illegal-argument
   ; just expecting this not to throw
   (json/encode {:foo "bar"}
-               {:pretty []}))
+               {:pretty []})
+  (json/encode {:foo "bar"}
+               {:pretty nil}))
 
 (deftest t-custom-pretty-print-with-defaults
   (let [test-obj (sorted-map :foo 1 :bar {:baz [{:ulu "mulu"} {:moot "foo"} 3]} :quux :blub)


### PR DESCRIPTION
Fixes #99

I didn't add too many options for now because I think indentation is the most important, let's see how the demand is there first.

The Java class exists because when I wrote the `PrettyPrinter` in idiomatic Clojure with `reify` I couldn't get the execution time below 75 µs (default pretty printer takes ~5 µs!). With this Java implementation it's now only slightly slower, around 7 µs.

EDIT: Oh, and now I see I completely fucked up your formatting. Let's see if I can fix this…

EDIT2: Should be fine now.