### PR TITLE
Fix for Java 1.6 and 1.7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,4 +38,5 @@
 ;;             "-XX:+PrintCompilation"
 ;;             "-XX:+UnlockDiagnosticVMOptions"
 ;;             "-XX:+PrintInlining"
-             ])
+             ]
+  :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"])


### PR DESCRIPTION
Change #99 introduced a Java class which is compiled ahead of time to
the JAR. By default the Java classes are built for use in current Java
version and to allow use in older Java versions an option has to be
provided.

Currently Cheshire is built on Java 1.8 and doesn't work at Java 1.6 or 1.7. This was noticed when Cheshire dependency on Ring-middleware-format was bumped to the latest version: https://travis-ci.org/ngrunwald/ring-middleware-format/jobs/122605740