### PR TITLE
Modernize and propagate type hints.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,20 +9,20 @@
                  [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.7.3"]
                  [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.7.3"]
                  [tigris "0.1.1"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/test.generative "0.1.4"]]}
-             :1.2 {:dependencies [[org.clojure/clojure "1.2.1"]]}
              :1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0-RC4"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha7"]]}
              :benchmark {:test-paths ["benchmarks"]
                          :jvm-opts ^:replace ["-Xms1g" "-Xmx1g" "-server"]
                          :dependencies [[criterium "0.4.4"]
                                         [org.clojure/data.json "0.2.6"]
                                         [clj-json "0.5.3"]]}}
-  :aliases {"all" ["with-profile" "dev,1.3:dev,1.4:dev,1.5:dev,1.7:dev,1.8:dev"]
+  :aliases {"all" ["with-profile" "dev,1.3:dev,1.4:dev,1.5:dev,1.7:dev,1.8:dev,1.9:dev"]
             "benchmark" ["with-profile" "dev,benchmark" "test"]
             "pretty-bench" ["with-profile" "dev,benchmark" "test" ":only"
                           "cheshire.test.benchmark/t-bench-pretty"]

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -45,14 +45,14 @@
         (.setObjectFieldValueSeparator object-field-value-separator))))
 
 ;; Generators
-(defn ^String generate-string
+(defn generate-string
   "Returns a JSON-encoding String for the given Clojure object. Takes an
   optional date format string that Date objects will be encoded with.
 
   The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-  ([obj]
+  (^String [obj]
    (generate-string obj nil))
-  ([obj opt-map]
+  (^String [obj opt-map]
    (let [sw (StringWriter.)
          generator (.createGenerator
                     ^JsonFactory (or factory/*json-factory*
@@ -77,15 +77,15 @@
      (.flush generator)
      (.toString sw))))
 
-(defn ^BufferedWriter generate-stream
+(defn generate-stream
   "Returns a BufferedWriter for the given Clojure object with the JSON-encoded
   data written to the writer. Takes an optional date format string that Date
   objects will be encoded with.
 
   The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-  ([obj ^BufferedWriter writer]
+  (^BufferedWriter [obj ^BufferedWriter writer]
    (generate-stream obj writer nil))
-  ([obj ^BufferedWriter writer opt-map]
+  (^BufferedWriter [obj ^BufferedWriter writer opt-map]
    (let [generator (.createGenerator
                     ^JsonFactory (or factory/*json-factory*
                                      factory/json-factory)
@@ -152,9 +152,9 @@
   Takes an optional date format string that Date objects will be encoded with.
 
   The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-  ([obj]
+  (^bytes [obj]
    (generate-smile obj nil))
-  ([obj opt-map]
+  (^bytes [obj opt-map]
    (let [baos (ByteArrayOutputStream.)
          generator (.createGenerator ^SmileFactory
                                      (or factory/*smile-factory*
@@ -172,9 +172,9 @@
   Takes an optional date format string that Date objects will be encoded with.
 
   The default date format (in UTC) is: yyyy-MM-dd'T'HH:mm:ss'Z'"
-  ([obj]
+  (^bytes [obj]
    (generate-cbor obj nil))
-  ([obj opt-map]
+  (^bytes [obj opt-map]
    (let [baos (ByteArrayOutputStream.)
          generator (.createGenerator ^CBORFactory
                                      (or factory/*cbor-factory*
@@ -330,10 +330,20 @@
                   key-fn array-coerce-fn))))
 
 ;; aliases for clojure-json users
+(defmacro copy-arglists
+  [dst src]
+  `(alter-meta! (var ~dst) merge (select-keys (meta (var ~src)) [:arglists])))
 (def encode "Alias to generate-string for clojure-json users" generate-string)
+(copy-arglists encode generate-string)
 (def encode-stream "Alias to generate-stream for clojure-json users" generate-stream)
+(copy-arglists encode-stream generate-stream)
 (def encode-smile "Alias to generate-smile for clojure-json users" generate-smile)
+(copy-arglists encode-smile generate-smile)
 (def decode "Alias to parse-string for clojure-json users" parse-string)
+(copy-arglists decode parse-string)
 (def decode-strict "Alias to parse-string-strict for clojure-json users" parse-string-strict)
+(copy-arglists decode-strict parse-string-strict)
 (def decode-stream "Alias to parse-stream for clojure-json users" parse-stream)
+(copy-arglists decode-stream parse-stream)
 (def decode-smile "Alias to parse-smile for clojure-json users" parse-smile)
+(copy-arglists decode-smile parse-smile)

--- a/src/cheshire/custom.clj
+++ b/src/cheshire/custom.clj
@@ -30,10 +30,10 @@
 (defprotocol JSONable
   (to-json [t jg]))
 
-(defn ^String encode*
-  ([obj]
+(defn encode*
+  (^String [obj]
      (encode* obj nil))
-  ([obj opt-map]
+  (^String [obj opt-map]
      (binding [*date-format* (or (:date-format opt-map) default-date-format)]
        (let [sw (StringWriter.)
              generator (.createJsonGenerator
@@ -48,12 +48,13 @@
          (.flush generator)
          (.toString sw)))))
 
-(def ^String encode encode*)
+(def encode encode*)
+(core/copy-arglists encode encode*)
 
-(defn ^String encode-stream*
-  ([obj ^BufferedWriter w]
+(defn encode-stream*
+  (^String [obj ^BufferedWriter w]
      (encode-stream* obj w nil))
-  ([obj ^BufferedWriter w opt-map]
+  (^String [obj ^BufferedWriter w opt-map]
      (binding [*date-format* (or (:date-format opt-map) default-date-format)]
        (let [generator (.createJsonGenerator
                         ^JsonFactory (or *json-factory* json-factory) w)]
@@ -65,12 +66,13 @@
          (.flush generator)
          w))))
 
-(def ^String encode-stream encode-stream*)
+(def encode-stream encode-stream*)
+(core/copy-arglists encode-stream encode-stream*)
 
 (defn encode-smile*
-  ([obj]
+  (^bytes [obj]
      (encode-smile* obj nil))
-  ([obj opt-map]
+  (^bytes [obj opt-map]
      (binding [*date-format* (or (:date-format opt-map) default-date-format)]
        (let [baos (ByteArrayOutputStream.)
              generator (.createJsonGenerator ^SmileFactory
@@ -81,26 +83,40 @@
          (.toByteArray baos)))))
 
 (def encode-smile encode-smile*)
+(core/copy-arglists encode-smile encode-smile*)
 
 ;; there are no differences in parsing, but these are here to make
 ;; this a self-contained namespace if desired
 (def parse core/decode)
+(core/copy-arglists parse core/decode)
 (def parse-string core/decode)
+(core/copy-arglists parse-string core/decode)
 (def parse-stream core/decode-stream)
+(core/copy-arglists parse-stream core/decode-stream)
 (def parse-smile core/decode-smile)
+(core/copy-arglists parse-smile core/decode-smile)
 (def parsed-seq core/parsed-seq)
+(core/copy-arglists parsed-seq core/parsed-seq)
 (def decode core/parse-string)
+(core/copy-arglists decode core/parse-string)
 (def decode-stream parse-stream)
+(core/copy-arglists decode-stream core/parse-stream)
 (def decode-smile parse-smile)
+(core/copy-arglists decode-smile core/parse-smile)
 
 ;; aliases for encoding
 (def generate-string encode*)
+(core/copy-arglists generate-string encode*)
 (def generate-string* encode*)
+(core/copy-arglists generate-string* encode*)
 (def generate-stream encode-stream*)
+(core/copy-arglists generate-stream encode-stream*)
 (def generate-stream* encode-stream*)
+(core/copy-arglists generate-stream* encode-stream*)
 (def generate-smile encode-smile*)
+(core/copy-arglists generate-smile encode-smile*)
 (def generate-smile* encode-smile*)
-
+(core/copy-arglists generate-smile* encode-smile*)
 
 ;; Generic encoders, these can be used by someone writing a custom
 ;; encoder if so desired, after transforming an arbitrary data

--- a/src/cheshire/factory.clj
+++ b/src/cheshire/factory.clj
@@ -22,8 +22,8 @@
    :canonicalize-field-names false})
 
 ;; Factory objects that are needed to do the encoding and decoding
-(defn ^JsonFactory make-json-factory
-  [opts]
+(defn make-json-factory
+  ^JsonFactory [opts]
   (let [opts (merge default-factory-options opts)]
     (doto (JsonFactory.)
       (.configure JsonParser$Feature/AUTO_CLOSE_SOURCE
@@ -47,8 +47,8 @@
       (.configure JsonFactory$Feature/CANONICALIZE_FIELD_NAMES
                   (boolean (:canonicalize-field-names opts))))))
 
-(defn ^SmileFactory make-smile-factory
-  [opts]
+(defn make-smile-factory
+  ^SmileFactory [opts]
   (let [opts (merge default-factory-options opts)]
     (doto (SmileFactory.)
       (.configure JsonParser$Feature/AUTO_CLOSE_SOURCE
@@ -72,8 +72,8 @@
       (.configure JsonFactory$Feature/CANONICALIZE_FIELD_NAMES
                   (boolean (:canonicalize-field-names opts))))))
 
-(defn ^CBORFactory make-cbor-factory
-  [opts]
+(defn make-cbor-factory
+  ^CBORFactory [opts]
   (let [opts (merge default-factory-options opts)]
     (doto (CBORFactory.)
       (.configure JsonParser$Feature/AUTO_CLOSE_SOURCE


### PR DESCRIPTION
I ran into reflection warnings when using `cheshire.core/encode`. Using `cheshire.core/generate-string` does not produce reflection warnings. I have made the following changes:

- Switch from deprecated type hinting for return types (on the var) to
  type hinting arg vectors.
- For alias vars (i.e. cheshire.core/decode) be sure to propagate the
  :arglists metadata so the type hints are carried over.
- Update clojure versions.

I droped the Clojure 1.2.1 profile, since it was not being used in the `all` alias, and the arg vector type hints were introduced in Clojure 1.3.

If Clojure 1.2.1 compatibility is still required, then let me know, and I can adjust the changes.