### PR TITLE
allow non const bools for key-fn

### DIFF
--- a/src/cheshire/parse.clj
+++ b/src/cheshire/parse.clj
@@ -84,7 +84,7 @@
       (parse* jp key-fn *use-bigdecimals?* array-coerce-fn))))
 
 (defn parse [^JsonParser jp key-fn eof array-coerce-fn]
-  (let [key-fn (or (if (identical? key-fn true) keyword key-fn) identity)]
+  (let [key-fn (or (if (and (instance? Boolean key-fn) key-fn) keyword key-fn) identity)]
     (.nextToken jp)
     (condp identical? (.getCurrentToken jp)
       nil

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -393,3 +393,6 @@
 
 (deftest t-float-encoding
   (is (= "{\"foo\":0.01}" (json/encode {:foo (float 0.01)}))))
+
+(deftest t-non-const-bools
+  (is (= {:a 1} (json/decode "{\"a\": 1}" (Boolean. true)))))


### PR DESCRIPTION
Ran into this because we use cheshire in some distributed environments where the arguments are serialized and deserialized, at which point they apparently become a true but different Boolean