### PR TITLE
Respect :indent-objects? false in pretty printer

### DIFF
--- a/src/java/cheshire/prettyprint/CustomPrettyPrinter.java
+++ b/src/java/cheshire/prettyprint/CustomPrettyPrinter.java
@@ -49,6 +49,8 @@ public class CustomPrettyPrinter extends DefaultPrettyPrinter {
         }
         if (indentObjects) {
             this.indentObjectsWith(indenter);
+        } else {
+            this.indentObjectsWith(new DefaultPrettyPrinter.FixedSpaceIndenter());
         }
         return this;
     }

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -305,6 +305,20 @@
       (println expected))
     (is (= expected pretty-str))))
 
+(deftest t-custom-pretty-print-with-noident-objects
+  (let [test-obj  [{:foo 1 :bar 2} {:foo 3 :bar 4}]
+        test-opts {:pretty {:indent-objects? false}}
+        expected (str "[ { \"foo\" : 1, \"bar\" : 2 }, "
+                      "{ \"foo\" : 3, \"bar\" : 4 } ]")
+        pretty-str (json/encode test-obj test-opts)]
+    ; just to be easy on the eyes in case of error
+    (when-not (= expected pretty-str)
+      (println "; pretty print with options - actual")
+      (println pretty-str)
+      (println "; pretty print with options - expected")
+      (println expected))
+    (is (= expected pretty-str))))
+
 (deftest t-unicode-escaping
   (is (= "{\"foo\":\"It costs \\u00A3100\"}"
          (json/encode {:foo "It costs £100"} {:escape-non-ascii true}))))


### PR DESCRIPTION
Currently, CustomPrettyPrinter ignores :indent-objects? false, taking no action. But it is using DefaultPrettyPrinter under the hood which indents objects by default. This commit changes this and explicitly sets a single space only indenter if `indent-objects?` is `false`.
Fixes #106.