### PR TITLE
[WIP] Add ability to parse parts of json

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ changed.
 (parsed-smile-seq (clojure.java.io/reader "/tmp/foo"))
 
 ;; parse a nested part of the stream lazily (keywords option also supported)
-(parsed-partial (clojure.java.io/reader "/tmp/foo") ["foo" "bar"])
+(parse-stream (clojure.java.io/reader "/tmp/foo") nil nil [#{"foo"} #{"bar"}] true)
 ```
 
 In 2.0.4 and up, Cheshire allows passing in a

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ changed.
 
 ;; parse a SMILE stream lazily (keywords option also supported)
 (parsed-smile-seq (clojure.java.io/reader "/tmp/foo"))
+
+;; parse a nested part of the stream lazily (keywords option also supported)
+(parsed-partial (clojure.java.io/reader "/tmp/foo") ["foo" "bar"])
 ```
 
 In 2.0.4 and up, Cheshire allows passing in a

--- a/benchmarks/cheshire/test/benchmark.clj
+++ b/benchmarks/cheshire/test/benchmark.clj
@@ -61,9 +61,10 @@
     (bench/bench (core/decode (core/encode test-obj)) :verbose))
   (println "........decode single nested property")
   (bench/with-progress-reporting
-    (bench/bench (core/parse-partial
-                  (big-test-reader "test/citylots.json.gz")
-                  ["features" 30 "properties" "STREET"]) :verbose))
+    (bench/bench (take 5 (core/parse-stream
+                          (big-test-reader "test/all_month.geojson.gz")
+                          nil nil
+                          [#{"features"} #{"properties"} #{"url"}] true)) :verbose))
   (println "-------------------------------------"))
 
 (deftest t-bench-pretty

--- a/benchmarks/cheshire/test/benchmark.clj
+++ b/benchmarks/cheshire/test/benchmark.clj
@@ -4,7 +4,7 @@
             [cheshire.custom :as old]
             [cheshire.generate :as custom]
             [clojure.data.json :as cj]
-            [clojure.java.io :refer [file input-stream resource]]
+            [clojure.java.io :refer [file input-stream resource reader]]
             [clj-json.core :as clj-json]
             [criterium.core :as bench])
   (:import (java.util.zip GZIPInputStream)))
@@ -29,11 +29,15 @@
    :indent-arrays? true
    :object-field-value-separator ": "})
 
-(def big-test-obj
-  (-> "test/all_month.geojson.gz"
+(defn big-test-reader [f]
+  (-> f
       file
       input-stream
-      (GZIPInputStream. )
+      (GZIPInputStream.)
+      reader))
+
+(def big-test-obj
+  (-> (big-test-reader "test/all_month.geojson.gz")
       slurp
       core/decode))
 
@@ -52,8 +56,14 @@
 
 (deftest t-bench-core
   (println "---------- Core Benchmarks ----------")
+  (println "........encode/decode full object")
   (bench/with-progress-reporting
     (bench/bench (core/decode (core/encode test-obj)) :verbose))
+  (println "........decode single nested property")
+  (bench/with-progress-reporting
+    (bench/bench (core/parse-partial
+                  (big-test-reader "test/citylots.json.gz")
+                  ["features" 30 "properties" "STREET"]) :verbose))
   (println "-------------------------------------"))
 
 (deftest t-bench-pretty

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -328,7 +328,7 @@
   ([reader xpath key-fn] (parsed-partial reader xpath key-fn nil))
   ([^BufferedReader reader xpath key-fn array-coerce-fn]
    (when (and reader (not-empty xpath))
-     (parse/parse-xpath
+     (parse/parse-json-path
       (.createParser ^JsonFactory
                      (or factory/*json-factory*
                          factory/json-factory)

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -199,15 +199,17 @@
 
   If the top-level object is an array, it will be parsed lazily (use
   `parse-strict' if strict parsing is required for top-level arrays."
-  ([string] (parse-string string nil nil))
-  ([string key-fn] (parse-string string key-fn nil))
-  ([^String string key-fn array-coerce-fn]
+  ([string] (parse-string string nil nil (repeat (constantly true)) false))
+  ([string key-fn] (parse-string string key-fn nil (repeat (constantly true)) false))
+  ([string key-fn array-coerce-fn] (parse-string string key-fn array-coerce-fn (repeat (constantly true)) false))
+  ([string key-fn array-coerce-fn pred-xs] (parse-string string key-fn array-coerce-fn pred-xs false))
+  ([^String string key-fn array-coerce-fn pred-xs detach-children?]
    (when string
      (parse/parse
       (.createParser ^JsonFactory (or factory/*json-factory*
                                       factory/json-factory)
                      ^Reader (StringReader. string))
-      key-fn nil array-coerce-fn))))
+      key-fn nil array-coerce-fn pred-xs detach-children?))))
 
 ;; Parsing strictly
 (defn parse-string-strict
@@ -219,15 +221,17 @@
   and returning the collection to be used for array values.
 
   Does not lazily parse top-level arrays."
-  ([string] (parse-string-strict string nil nil))
-  ([string key-fn] (parse-string-strict string key-fn nil))
-  ([^String string key-fn array-coerce-fn]
+  ([string] (parse-string-strict string nil nil (repeat (constantly true)) false))
+  ([string key-fn] (parse-string-strict string key-fn nil (repeat (constantly true)) false))
+  ([string key-fn array-coerce-fn] (parse-string-strict string key-fn array-coerce-fn (repeat (constantly true)) false))
+  ([string key-fn array-coerce-fn pred-xs] (parse-string-strict string key-fn array-coerce-fn pred-xs false))
+  ([^String string key-fn array-coerce-fn pred-xs detach-children?]
    (when string
      (parse/parse-strict
       (.createParser ^JsonFactory (or factory/*json-factory*
                                       factory/json-factory)
                      ^Reader (StringReader. string))
-      key-fn nil array-coerce-fn))))
+      key-fn nil array-coerce-fn pred-xs detach-children?))))
 
 (defn parse-stream
   "Returns the Clojure object corresponding to the given reader, reader must
@@ -243,15 +247,17 @@
 
   If multiple objects (enclosed in a top-level `{}' need to be parsed lazily,
   see parsed-seq."
-  ([rdr] (parse-stream rdr nil nil))
-  ([rdr key-fn] (parse-stream rdr key-fn nil))
-  ([^BufferedReader rdr key-fn array-coerce-fn]
+  ([rdr] (parse-stream rdr nil nil (repeat (constantly true)) false))
+  ([rdr key-fn] (parse-stream rdr key-fn nil (repeat (constantly true)) false))
+  ([rdr key-fn array-coerce-fn] (parse-stream rdr key-fn array-coerce-fn (repeat (constantly true)) false))
+  ([rdr key-fn array-coerce-fn pred-xs] (parse-stream rdr key-fn array-coerce-fn pred-xs false))
+  ([^BufferedReader rdr key-fn array-coerce-fn pred-xs detach-children?]
    (when rdr
      (parse/parse
       (.createParser ^JsonFactory (or factory/*json-factory*
                                       factory/json-factory)
                      ^Reader rdr)
-      key-fn nil array-coerce-fn))))
+      key-fn nil array-coerce-fn pred-xs detach-children?))))
 
 (defn parse-smile
   "Returns the Clojure object corresponding to the given SMILE-encoded bytes.
@@ -260,14 +266,16 @@
 
   The array-coerce-fn is an optional function taking the name of an array field,
   and returning the collection to be used for array values."
-  ([bytes] (parse-smile bytes nil nil))
-  ([bytes key-fn] (parse-smile bytes key-fn nil))
-  ([^bytes bytes key-fn array-coerce-fn]
+  ([bytes] (parse-smile bytes nil nil (repeat (constantly true)) false))
+  ([bytes key-fn] (parse-smile bytes key-fn nil (repeat (constantly true)) false))
+  ([bytes key-fn array-coerce-fn] (parse-smile bytes key-fn array-coerce-fn (repeat (constantly true)) false))
+  ([bytes key-fn array-coerce-fn pred-xs] (parse-smile bytes key-fn array-coerce-fn pred-xs false))
+  ([^bytes bytes key-fn array-coerce-fn pred-xs detach-children?]
    (when bytes
      (parse/parse
       (.createParser ^SmileFactory (or factory/*smile-factory*
                                        factory/smile-factory) bytes)
-      key-fn nil array-coerce-fn))))
+      key-fn nil array-coerce-fn pred-xs detach-children?))))
 
 (defn parse-cbor
   "Returns the Clojure object corresponding to the given CBOR-encoded bytes.
@@ -276,14 +284,16 @@
 
   The array-coerce-fn is an optional function taking the name of an array field,
   and returning the collection to be used for array values."
-  ([bytes] (parse-cbor bytes nil nil))
-  ([bytes key-fn] (parse-cbor bytes key-fn nil))
-  ([^bytes bytes key-fn array-coerce-fn]
+  ([bytes] (parse-cbor bytes nil nil (repeat (constantly true)) false))
+  ([bytes key-fn] (parse-cbor bytes key-fn nil (repeat (constantly true)) false))
+  ([bytes key-fn array-coerce-fn] (parse-cbor bytes key-fn array-coerce-fn (repeat (constantly true)) false))
+  ([bytes key-fn array-coerce-fn pred-xs] (parse-cbor bytes key-fn array-coerce-fn pred-xs false))
+  ([^bytes bytes key-fn array-coerce-fn pred-xs detach-children?]
    (when bytes
      (parse/parse
       (.createParser ^CBORFactory (or factory/*cbor-factory*
                                       factory/cbor-factory) bytes)
-      key-fn nil array-coerce-fn))))
+      key-fn nil array-coerce-fn pred-xs detach-children?))))
 
 (def ^{:doc "Object used to determine end of lazy parsing attempt."}
   eof (Object.))
@@ -291,11 +301,11 @@
 ;; Lazy parsers
 (defn- parsed-seq*
   "Internal lazy-seq parser"
-  [^JsonParser parser key-fn array-coerce-fn]
+  [^JsonParser parser key-fn array-coerce-fn pred-xs detach-children?]
   (lazy-seq
-   (let [elem (parse/parse-strict parser key-fn eof array-coerce-fn)]
+   (let [elem (parse/parse-strict parser key-fn eof array-coerce-fn pred-xs detach-children?)]
      (when-not (identical? elem eof)
-       (cons elem (parsed-seq* parser key-fn array-coerce-fn))))))
+       (cons elem (parsed-seq* parser key-fn array-coerce-fn pred-xs detach-children?))))))
 
 (defn parsed-seq
   "Returns a lazy seq of Clojure objects corresponding to the JSON read from
@@ -304,36 +314,17 @@
   The array-coerce-fn is an optional function taking the name of an array field,
   and returning the collection to be used for array values.
   If non-laziness is needed, see parse-stream."
-  ([reader] (parsed-seq reader nil nil))
-  ([reader key-fn] (parsed-seq reader key-fn nil))
-  ([^BufferedReader reader key-fn array-coerce-fn]
+  ([reader] (parsed-seq reader nil nil (repeat (constantly true)) false))
+  ([reader key-fn] (parsed-seq reader key-fn nil (repeat (constantly true)) false))
+  ([reader key-fn array-coerce-fn] (parsed-seq reader key-fn array-coerce-fn (repeat (constantly true)) false))
+  ([reader key-fn array-coerce-fn pred-xs] (parsed-seq reader key-fn array-coerce-fn pred-xs false))
+  ([^BufferedReader reader key-fn array-coerce-fn pred-xs detach-children?]
    (when reader
      (parsed-seq* (.createParser ^JsonFactory
                                  (or factory/*json-factory*
                                      factory/json-factory)
                                  ^Reader reader)
-                  key-fn array-coerce-fn))))
-
-;; Partial parsers
-(defn parsed-partial
-  "Returns a Clojure object corresponding to the JSON read from the given reader
-  starting from the point identified as xpath passed as second argument.
-  xpath must be a sequence of attribute names or array indexes.
-  E.g. `[\"root\" \"first-level\" 10 \"second-level\"]`
-  Attribute name should be same type as a result of key-fn (if used).
-
-  The array-coerce-fn is an optional function taking the name of an array field,
-  and returning the collection to be used for array values."
-  ([reader xpath] (parsed-partial reader xpath nil nil))
-  ([reader xpath key-fn] (parsed-partial reader xpath key-fn nil))
-  ([^BufferedReader reader xpath key-fn array-coerce-fn]
-   (when (and reader (not-empty xpath))
-     (parse/parse-json-path
-      (.createParser ^JsonFactory
-                     (or factory/*json-factory*
-                         factory/json-factory)
-                     ^Reader reader)
-      key-fn eof array-coerce-fn xpath))))
+                  key-fn array-coerce-fn pred-xs detach-children?))))
 
 (defn parsed-smile-seq
   "Returns a lazy seq of Clojure objects corresponding to the SMILE read from
@@ -341,15 +332,17 @@
 
   The array-coerce-fn is an optional function taking the name of an array field,
   and returning the collection to be used for array values."
-  ([reader] (parsed-smile-seq reader nil nil))
-  ([reader key-fn] (parsed-smile-seq reader key-fn nil))
-  ([^BufferedReader reader key-fn array-coerce-fn]
+  ([reader] (parsed-smile-seq reader nil nil (repeat (constantly true)) false))
+  ([reader key-fn] (parsed-smile-seq reader key-fn nil (repeat (constantly true)) false))
+  ([reader key-fn array-coerce-fn] (parsed-smile-seq reader key-fn array-coerce-fn (repeat (constantly true)) false))
+  ([reader key-fn array-coerce-fn pred-xs] (parsed-smile-seq reader key-fn array-coerce-fn pred-xs false))
+  ([^BufferedReader reader key-fn array-coerce-fn pred-xs detach-children?]
    (when reader
      (parsed-seq* (.createParser ^SmileFactory
                                  (or factory/*smile-factory*
                                      factory/smile-factory)
                                  ^Reader reader)
-                  key-fn array-coerce-fn))))
+                  key-fn array-coerce-fn pred-xs detach-children?))))
 
 ;; aliases for clojure-json users
 (defmacro copy-arglists

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -314,6 +314,27 @@
                                  ^Reader reader)
                   key-fn array-coerce-fn))))
 
+;; Partial parsers
+(defn parse-path
+  "Returns a Clojure object corresponding to the JSON read from the given reader
+  starting from the point identified as xpath passed as second argument.
+  xpath must be a sequence of attribute names or array indexes.
+  E.g. `[\"root\" \"first-level\" 10 \"second-level\"]`
+  Attribute name should be same type as a result of key-fn (if used).
+
+  The array-coerce-fn is an optional function taking the name of an array field,
+  and returning the collection to be used for array values."
+  ([reader xpath] (parse-path reader xpath nil nil))
+  ([reader xpath key-fn] (parse-path reader xpath key-fn nil))
+  ([^BufferedReader reader xpath key-fn array-coerce-fn]
+   (when (and reader (not-empty xpath))
+     (parse/parse-xpath
+      (.createParser ^JsonFactory
+                     (or factory/*json-factory*
+                         factory/json-factory)
+                     ^Reader reader)
+      key-fn eof array-coerce-fn xpath))))
+
 (defn parsed-smile-seq
   "Returns a lazy seq of Clojure objects corresponding to the SMILE read from
   the given reader. The seq continues until the end of the reader is reached.

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -315,7 +315,7 @@
                   key-fn array-coerce-fn))))
 
 ;; Partial parsers
-(defn parse-path
+(defn parsed-partial
   "Returns a Clojure object corresponding to the JSON read from the given reader
   starting from the point identified as xpath passed as second argument.
   xpath must be a sequence of attribute names or array indexes.
@@ -324,8 +324,8 @@
 
   The array-coerce-fn is an optional function taking the name of an array field,
   and returning the collection to be used for array values."
-  ([reader xpath] (parse-path reader xpath nil nil))
-  ([reader xpath key-fn] (parse-path reader xpath key-fn nil))
+  ([reader xpath] (parsed-partial reader xpath nil nil))
+  ([reader xpath key-fn] (parsed-partial reader xpath key-fn nil))
   ([^BufferedReader reader xpath key-fn array-coerce-fn]
    (when (and reader (not-empty xpath))
      (parse/parse-xpath

--- a/src/cheshire/exact.clj
+++ b/src/cheshire/exact.clj
@@ -18,24 +18,28 @@
 (defn parse-string
   "Like cheshire.core/parse-string
   but with only valid json string"
-  ([string] (parse-string string nil nil))
-  ([string key-fn] (parse-string string key-fn nil))
-  ([^String string key-fn array-coerce-fn]
+  ([string] (parse-string string nil nil (repeat (constantly true)) false))
+  ([string key-fn] (parse-string string key-fn nil (repeat (constantly true)) false))
+  ([string key-fn array-coerce-fn] (parse-string string key-fn array-coerce-fn (repeat (constantly true)) false))
+  ([string key-fn array-coerce-fn pred-xs] (parse-string string key-fn array-coerce-fn pred-xs false))
+  ([^String string key-fn array-coerce-fn pred-xs detach-children?]
    (when string
      (let [jp (.createParser ^JsonFactory (or factory/*json-factory*
                                               factory/json-factory)
                              ^Reader (StringReader. string))]
-       (exact-parse jp (parse/parse jp key-fn nil array-coerce-fn))))))
+       (exact-parse jp (parse/parse jp key-fn nil array-coerce-fn pred-xs detach-children?))))))
 
 (defn parse-string-strict
-  ([string] (parse-string-strict string nil nil))
-  ([string key-fn] (parse-string-strict string key-fn nil))
-  ([^String string key-fn array-coerce-fn]
+  ([string] (parse-string-strict string nil nil (repeat (constantly true)) false))
+  ([string key-fn] (parse-string-strict string key-fn nil (repeat (constantly true)) false))
+  ([string key-fn array-coerce-fn] (parse-string-strict string key-fn array-coerce-fn (repeat (constantly true)) false))
+  ([string key-fn array-coerce-fn pred-xs] (parse-string-strict string key-fn array-coerce-fn pred-xs false))
+  ([^String string key-fn array-coerce-fn pred-xs detach-children?]
    (when string
      (let [jp (.createParser ^JsonFactory (or factory/*json-factory*
                                               factory/json-factory)
                              ^Writer (StringReader. string))]
-       (exact-parse jp (parse/parse-strict jp key-fn nil array-coerce-fn))))))
+       (exact-parse jp (parse/parse-strict jp key-fn nil array-coerce-fn pred-xs detach-children?))))))
 
 (def decode parse-string)
 (core/copy-arglists decode parse-string)

--- a/src/cheshire/parse.clj
+++ b/src/cheshire/parse.clj
@@ -99,12 +99,15 @@
 (defn- parse-xpath* [xpath ^JsonParser jp key-fn bd? array-coerce-fn]
   (if-let [fxpath (first xpath)]
     (cond
-      (and (number? fxpath)
+      (and (or (number? fxpath)
+               (= fxpath "*"))
            (identical? JsonToken/START_ARRAY (.getCurrentToken jp)))
-      (last (take (inc fxpath)
-                  (do
-                    (.nextToken jp)
-                    (lazily-parse-array jp key-fn bd? array-coerce-fn (partial parse-xpath* (rest xpath))))))
+      (do
+        (.nextToken jp)
+        (if (= fxpath "*")
+          (lazily-parse-array jp key-fn bd? array-coerce-fn (partial parse-xpath* (rest xpath)))
+          (last (take (inc fxpath)
+                      (lazily-parse-array jp key-fn bd? array-coerce-fn (partial parse-xpath* (rest xpath)))))))
 
       (or (string? fxpath)
           (keyword? fxpath))

--- a/src/cheshire/parse.clj
+++ b/src/cheshire/parse.clj
@@ -12,7 +12,7 @@
   ([obj]
      `(vary-meta ~obj assoc :tag `JsonParser)))
 
-(definline parse-object [^JsonParser jp key-fn bd? array-coerce-fn]
+(definline parse-object [^JsonParser jp key-fn bd? array-coerce-fn pred-xs detach-children?]
   (let [jp (tag jp)]
     `(do
        (.nextToken ~jp)
@@ -22,31 +22,21 @@
            (let [key-str# (.getText ~jp)
                  _# (.nextToken ~jp)
                  key# (~key-fn key-str#)
-                 mmap# (assoc! mmap# key#
-                               (parse* ~jp ~key-fn ~bd? ~array-coerce-fn))]
+                 pred# (or (first ~pred-xs) (constantly true))
+                 match?# (pred# key#)
+                 val# (when match?# (parse* ~jp ~key-fn ~bd? ~array-coerce-fn (next ~pred-xs) ~detach-children?))
+                 mmap# (if match?#
+                         (assoc! mmap# key# val#)
+                         (do
+                           (.skipChildren ~jp)
+                           mmap#))]
              (.nextToken ~jp)
-             (recur mmap#))
+             (if (and ~detach-children? match?#)
+               val#
+               (recur mmap#)))
            (persistent! mmap#))))))
 
-(definline parse-object-xpath [^JsonParser jp key-fn bd? array-coerce-fn fxpath parse-fn]
-  (let [jp (tag jp)]
-    `(do
-       (.nextToken ~jp)
-       (loop []
-         (if-not (identical? (.getCurrentToken ~jp)
-                             JsonToken/END_OBJECT)
-           (let [key-str# (.getText ~jp)
-                 _# (.nextToken ~jp)
-                 key# (~key-fn key-str#)]
-             (if-not (= key# ~fxpath)
-               (do
-                 (.skipChildren ~jp)
-                 (.nextToken ~jp)
-                 (recur))
-               (~parse-fn ~jp ~key-fn ~bd? ~array-coerce-fn)))
-           nil)))))
-
-(definline parse-array [^JsonParser jp key-fn bd? array-coerce-fn]
+(definline parse-array [^JsonParser jp key-fn bd? array-coerce-fn pred-xs]
   (let [jp (tag jp)]
     `(let [array-field-name# (.getCurrentName ~jp)]
        (.nextToken ~jp)
@@ -56,79 +46,60 @@
          (if-not (identical? (.getCurrentToken ~jp)
                              JsonToken/END_ARRAY)
            (let [coll# (conj! coll#
-                              (parse* ~jp ~key-fn ~bd? ~array-coerce-fn))]
+                              (parse* ~jp ~key-fn ~bd? ~array-coerce-fn ~pred-xs))]
              (.nextToken ~jp)
              (recur coll#))
            (persistent! coll#))))))
 
 (defn lazily-parse-array
-  ([jp key-fn bd? array-coerce-fn]
-   (lazily-parse-array jp key-fn bd? array-coerce-fn parse*))
-  ([^JsonParser jp key-fn bd? array-coerce-fn parse-fn]
-   (lazy-seq
-    (loop [chunk-idx 0, buf (chunk-buffer 32)]
-      (if (identical? (.getCurrentToken jp) JsonToken/END_ARRAY)
-        (chunk-cons (chunk buf) nil)
-        (do
-          (chunk-append buf (parse-fn jp key-fn bd? array-coerce-fn))
-          (.nextToken jp)
-          (let [chunk-idx* (unchecked-inc chunk-idx)]
-            (if (< chunk-idx* 32)
-              (recur chunk-idx* buf)
-              (chunk-cons
-               (chunk buf)
-               (lazily-parse-array jp key-fn bd? array-coerce-fn parse-fn))))))))))
+  ([^JsonParser jp key-fn bd? array-coerce-fn pred-xs]
+   (let [pred-xs (or pred-xs (repeat (constantly true)))]
+     (lazy-seq
+      (loop [chunk-idx 0, buf (chunk-buffer 32)]
+        (if (identical? (.getCurrentToken jp) JsonToken/END_ARRAY)
+          (chunk-cons (chunk buf) nil)
+          (do
+            (chunk-append buf (parse* jp key-fn bd? array-coerce-fn pred-xs))
+            (.nextToken jp)
+            (let [chunk-idx* (unchecked-inc chunk-idx)]
+              (if (< chunk-idx* 32)
+                (recur chunk-idx* buf)
+                (chunk-cons
+                 (chunk buf)
+                 (lazily-parse-array jp key-fn bd? array-coerce-fn pred-xs)))))))))))
 
-(defn parse* [^JsonParser jp key-fn bd? array-coerce-fn]
-  (condp identical? (.getCurrentToken jp)
-    JsonToken/START_OBJECT (parse-object jp key-fn bd? array-coerce-fn)
-    JsonToken/START_ARRAY (parse-array jp key-fn bd? array-coerce-fn)
-    JsonToken/VALUE_STRING (.getText jp)
-    JsonToken/VALUE_NUMBER_INT (.getNumberValue jp)
-    JsonToken/VALUE_NUMBER_FLOAT (if bd?
-                                   (.getDecimalValue jp)
-                                   (.getNumberValue jp))
-    JsonToken/VALUE_EMBEDDED_OBJECT (.getBinaryValue jp)
-    JsonToken/VALUE_TRUE true
-    JsonToken/VALUE_FALSE false
-    JsonToken/VALUE_NULL nil
-    (throw
-     (Exception.
-      (str "Cannot parse " (pr-str (.getCurrentToken jp)))))))
+(defn parse*
+  ([jp key-fn bd? array-coerce-fn pred-xs] (parse* jp key-fn bd? array-coerce-fn pred-xs false))
+  ([^JsonParser jp key-fn bd? array-coerce-fn pred-xs detach-children?]
+   (condp identical? (.getCurrentToken jp)
+     JsonToken/START_OBJECT (parse-object jp key-fn bd? array-coerce-fn pred-xs (if-not (first pred-xs)
+                                                                                  false
+                                                                                  detach-children?))
+     JsonToken/START_ARRAY (if detach-children?
+                             (lazily-parse-array jp key-fn bd? array-coerce-fn pred-xs)
+                             (parse-array jp key-fn bd? array-coerce-fn pred-xs))
+     JsonToken/VALUE_STRING (.getText jp)
+     JsonToken/VALUE_NUMBER_INT (.getNumberValue jp)
+     JsonToken/VALUE_NUMBER_FLOAT (if bd?
+                                    (.getDecimalValue jp)
+                                    (.getNumberValue jp))
+     JsonToken/VALUE_EMBEDDED_OBJECT (.getBinaryValue jp)
+     JsonToken/VALUE_TRUE true
+     JsonToken/VALUE_FALSE false
+     JsonToken/VALUE_NULL nil
+     (throw
+      (Exception.
+       (str "Cannot parse " (pr-str (.getCurrentToken jp))))))))
 
-(defn- parse-json-path* [json-path ^JsonParser jp key-fn bd? array-coerce-fn]
-  (if-let [f-json-path (first json-path)]
-    (cond
-      (and (or (number? f-json-path)
-               (= f-json-path "*"))
-           (identical? JsonToken/START_ARRAY (.getCurrentToken jp)))
-      (do
-        (.nextToken jp)
-        (let [parse-child (partial parse-json-path* (rest json-path))
-              children (lazily-parse-array jp key-fn bd? array-coerce-fn parse-child)]
-          (if (= f-json-path "*")
-            children
-            (last (take (inc f-json-path) children)))))
-
-      (or (string? f-json-path)
-          (keyword? f-json-path))
-      (parse-object
-       jp key-fn bd? array-coerce-fn f-json-path
-       (partial parse-json-path* (rest json-path)))
-
-      :otherwise
-      nil)
-    (parse* jp key-fn bd? array-coerce-fn)))
-
-(defn parse-strict [^JsonParser jp key-fn eof array-coerce-fn]
+(defn parse-strict [^JsonParser jp key-fn eof array-coerce-fn pred-xs detach-children?]
   (let [key-fn (or (if (identical? key-fn true) keyword key-fn) identity)]
     (.nextToken jp)
     (condp identical? (.getCurrentToken jp)
       nil
       eof
-      (parse* jp key-fn *use-bigdecimals?* array-coerce-fn))))
+      (parse* jp key-fn *use-bigdecimals?* array-coerce-fn pred-xs detach-children?))))
 
-(defn parse [^JsonParser jp key-fn eof array-coerce-fn]
+(defn parse [^JsonParser jp key-fn eof array-coerce-fn pred-xs detach-children?]
   (let [key-fn (or (if (and (instance? Boolean key-fn) key-fn) keyword key-fn) identity)]
     (.nextToken jp)
     (condp identical? (.getCurrentToken jp)
@@ -138,15 +109,6 @@
       JsonToken/START_ARRAY
       (do
         (.nextToken jp)
-        (lazily-parse-array jp key-fn *use-bigdecimals?* array-coerce-fn))
+        (lazily-parse-array jp key-fn *use-bigdecimals?* array-coerce-fn pred-xs))
 
-      (parse* jp key-fn *use-bigdecimals?* array-coerce-fn))))
-
-(defn parse-json-path [^JsonParser jp key-fn eof array-coerce-fn xpath]
-  (let [key-fn (or (if (identical? key-fn true) keyword key-fn) identity)]
-    (.nextToken jp)
-    (condp identical? (.getCurrentToken jp)
-      nil
-      eof
-
-      (parse-json-path* xpath jp key-fn *use-bigdecimals?* array-coerce-fn))))
+      (parse* jp key-fn *use-bigdecimals?* array-coerce-fn pred-xs detach-children?))))

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -104,6 +104,16 @@
   (let [br (BufferedReader. (StringReader. "1\n2\n3\n"))]
     (is (= (list 1 2 3) (json/parsed-seq br)))))
 
+(deftest test-parsed-partial
+  (let [br (BufferedReader. (StringReader. "[1,\n2,\n3\n]"))]
+    (is (= 1 (json/parsed-partial br [0]))))
+  (let [br (BufferedReader. (StringReader. "{\"foo\":{\"bar\":1}}"))]
+    (is (= 1 (json/parsed-partial br ["foo" "bar"]))))
+  (let [br (BufferedReader. (StringReader. "{\"foo\":{\"bar\":1}}"))]
+    (is (= 1 (json/parsed-partial br [:foo :bar] true))))
+  (let [br (BufferedReader. (StringReader. "{\"foo\":{\"bar\": [{\"foo\": \"1\"}]}}"))]
+    (is (= {"foo" "1"} (json/parsed-partial br ["foo" "bar" 0])))))
+
 (deftest test-smile-round-trip
   (is (= test-obj (json/parse-smile (json/generate-smile test-obj)))))
 

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -112,7 +112,10 @@
   (let [br (BufferedReader. (StringReader. "{\"foo\":{\"bar\":1}}"))]
     (is (= 1 (json/parsed-partial br [:foo :bar] true))))
   (let [br (BufferedReader. (StringReader. "{\"foo\":{\"bar\": [{\"foo\": \"1\"}]}}"))]
-    (is (= {"foo" "1"} (json/parsed-partial br ["foo" "bar" 0])))))
+    (is (= {"foo" "1"} (json/parsed-partial br ["foo" "bar" 0]))))
+  (let [br (BufferedReader. (StringReader. "{\"foo\":{\"bar\": [{\"foo\": \"1\"},{\"foo\": 2}, {\"foo\": 3}]}}"))]
+    (is (= [{"foo" "1"} {"foo" 2}]
+           (take 2 (json/parsed-partial br ["foo" "bar" "*"]))))))
 
 (deftest test-smile-round-trip
   (is (= test-obj (json/parse-smile (json/generate-smile test-obj)))))


### PR DESCRIPTION
New core function to parse parts of json from the stream (potentially large one)

```
(parse-stream rdr nil nil [#{"some"} #{"nested"} #{"attributes"}])
(parse-stream rdr nil nil [#{:using} #{:key-fn}] true)
```

Few more tests added to track the performance.

Right now parts can be retrieved by the path passed as a set of predicates as a second argument.

Lazy seq will return when the path points to the key which contains the array and argument `detach-children?` is `true`.

```
;; {"foo": [{"bar": 1}, {"bar": 2}]}
(take 1 (parse-stream rdr nil nil [#{"foo"}] true))
;; => ({"bar" 1})
```

And you can continue the path after array pointer to return partial objects from array as lazy seq.
```
(def jstr "{\"foo\": [{\"bar\": 1}, {\"bar\": 2, \"baz\": 3}]}")
(def x (parse-string jstr nil nil [#{"foo"} #{"bar"}] true))
(type x) ;; => clojure.lang.LazySeq
(second x) ;; => {"bar" 2}
```
As you can see it works with parse-string as well (and with all other public functions)

Should fix #62 

TODO:
  * consider to use [jsonPath](https://goessner.net/articles/JsonPath/index.html#e2) to build a list of predicates from the string