### PR TITLE
Allow configurable chunk size in lazy seqs

### DIFF
--- a/src/cheshire/parse.clj
+++ b/src/cheshire/parse.clj
@@ -3,6 +3,8 @@
 
 (declare parse*)
 
+(def ^:dynamic *chunk-size* 32)
+
 (def ^{:doc "Flag to determine whether float values should be returned as
              BigDecimals to retain precision. Defaults to false."
        :dynamic true}
@@ -45,14 +47,14 @@
 
 (defn lazily-parse-array [^JsonParser jp key-fn bd? array-coerce-fn]
   (lazy-seq
-   (loop [chunk-idx 0, buf (chunk-buffer 32)]
+   (loop [chunk-idx 0, buf (chunk-buffer *chunk-size*)]
      (if (identical? (.getCurrentToken jp) JsonToken/END_ARRAY)
        (chunk-cons (chunk buf) nil)
        (do
          (chunk-append buf (parse* jp key-fn bd? array-coerce-fn))
          (.nextToken jp)
          (let [chunk-idx* (unchecked-inc chunk-idx)]
-           (if (< chunk-idx* 32)
+           (if (< chunk-idx* *chunk-size*)
              (recur chunk-idx* buf)
              (chunk-cons
               (chunk buf)


### PR DESCRIPTION
We ran into a case where a single item from the seq could fit into memory, but 32 could not. This just makes `32` a dynamic var instead of hardcoding it, so if desired the user can do something like:

```
(binding [cheshire.parse/*chunk-size* 8]
 (cheshire/parse-stream s))
```