### PR TITLE
Replace oraclejdk8 with openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
     - master
 jdk:
   - openjdk7
-  - oraclejdk8
+  - openjdk8
   - openjdk9
   - openjdk10
   - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ branches:
   only:
     - master
 jdk:
-  - openjdk7
   - openjdk8
   - openjdk9
   - openjdk10


### PR DESCRIPTION
TravisCI's Xenial environment no longer provides this environment.