### PR TITLE
Pin dist to trusty to build openjdk7 and oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: clojure
 lein: lein
 script: lein all test :all
+dist: trusty
 branches:
   only:
     - master


### PR DESCRIPTION
The newer build image `xenial` does not support openjdk7. See #146 for an alternative way of solving this issue.