### PR TITLE
Add missing quotation in dependency string

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ encoders.
 ## Usage
 
 ```clojure
-[cheshire "5.9.0]
+[cheshire "5.9.0"]
 
 ;; Cheshire v5.9.0 uses Jackson 2.9.9
 


### PR DESCRIPTION
The README file was missing a closing quote, making copy-paste of the dependency string introduce errors into a project.clj file.