### PR TITLE
Add Clojure factory keyword for strict duplicate detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,9 +311,9 @@ It's experimental, like the name says. Based on [Tigris](http://github.com/dakro
 
 ## Advanced customization for factories
 See
-[this](http://fasterxml.github.com/jackson-core/javadoc/2.1.1/com/fasterxml/jackson/core/JsonFactory.Feature.html)
+[this](http://fasterxml.github.com/jackson-core/javadoc/2.10/com/fasterxml/jackson/core/JsonFactory.Feature.html)
 and
-[this](http://fasterxml.github.com/jackson-core/javadoc/2.1.1/com/fasterxml/jackson/core/JsonParser.Feature.html)
+[this](http://fasterxml.github.com/jackson-core/javadoc/2.10/com/fasterxml/jackson/core/JsonParser.Feature.html)
 for a list of features that can be customized if desired. A custom
 factory can be used like so:
 

--- a/src/cheshire/factory.clj
+++ b/src/cheshire/factory.clj
@@ -21,7 +21,8 @@
    :allow-non-numeric-numbers false
    :intern-field-names false
    :canonicalize-field-names false
-   :quote-field-names true})
+   :quote-field-names true
+   :strict-duplicate-detection false})
 
 ;; Factory objects that are needed to do the encoding and decoding
 (defn make-json-factory
@@ -44,6 +45,8 @@
                   (boolean (:allow-numeric-leading-zeros opts)))
       (.configure JsonParser$Feature/ALLOW_NON_NUMERIC_NUMBERS
                   (boolean (:allow-non-numeric-numbers opts)))
+      (.configure JsonParser$Feature/STRICT_DUPLICATE_DETECTION
+                  (boolean (:strict-duplicate-detection opts)))
       (.configure JsonFactory$Feature/INTERN_FIELD_NAMES
                   (boolean (:intern-field-names opts)))
       (.configure JsonFactory$Feature/CANONICALIZE_FIELD_NAMES


### PR DESCRIPTION
The commit should speak for itself; strict duplicate detection is quite helpful for preventing decoder mismatch attacks.

It might be worthwhile to make it default to `true`, but I wanted to make sure this pull request was backwards compatible.