### PR TITLE
deps: upgrade jackson from 2.10.2 -> 2.12.2 (CVE-2020-28491)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,9 @@
             :url "http://opensource.org/licenses/MIT"
             :distribution :repo}
   :global-vars {*warn-on-reflection* false}
-  :dependencies [[com.fasterxml.jackson.core/jackson-core "2.10.2"]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.10.2"]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.10.2"]
+  :dependencies [[com.fasterxml.jackson.core/jackson-core "2.12.2"]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.12.2"]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.12.2"]
                  [tigris "0.1.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.1"]
                                   [org.clojure/test.generative "0.1.4"]


### PR DESCRIPTION
:wave: there

This upgrades Jackson to `v2.12.2` (latest at the time of this PR) to fix the security vulnerability [CVE-2020-28491](https://nvd.nist.gov/vuln/detail/CVE-2020-28491)

I'm not sure if this codepath can or cannot be hit in the first place but considering that this is probably flagging up as a vulnerability in a lot of dependant projects it would be good to get this version upgrade in as to avoid unnecessary noise in vulnerability reports.

see also https://github.com/dakrone/cheshire/pull/164 - this is just a newer version as that PR had a comment on it asking for `v2.12.x`

:lock: 