### PR TITLE
Create parsers via protocols

### DIFF
--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -243,7 +243,7 @@
   see parsed-seq."
   ([rdr] (parse-stream rdr nil nil))
   ([rdr key-fn] (parse-stream rdr key-fn nil))
-  ([^BufferedReader rdr key-fn array-coerce-fn]
+  ([rdr key-fn array-coerce-fn]
    (when rdr
      (parse/parse
       (parse/json-parser rdr)
@@ -261,7 +261,7 @@
   Does not lazily parse top-level arrays."
   ([rdr] (parse-stream-strict rdr nil nil))
   ([rdr key-fn] (parse-stream-strict rdr key-fn nil))
-  ([^BufferedReader rdr key-fn array-coerce-fn]
+  ([rdr key-fn array-coerce-fn]
    (when rdr
      (parse/parse-strict
        (parse/json-parser rdr)
@@ -276,7 +276,7 @@
   and returning the collection to be used for array values."
   ([bytes] (parse-smile bytes nil nil))
   ([bytes key-fn] (parse-smile bytes key-fn nil))
-  ([^bytes bytes key-fn array-coerce-fn]
+  ([bytes key-fn array-coerce-fn]
    (when bytes
      (parse/parse
       (parse/smile-parser bytes)
@@ -291,7 +291,7 @@
   and returning the collection to be used for array values."
   ([bytes] (parse-cbor bytes nil nil))
   ([bytes key-fn] (parse-cbor bytes key-fn nil))
-  ([^bytes bytes key-fn array-coerce-fn]
+  ([bytes key-fn array-coerce-fn]
    (when bytes
      (parse/parse
       (parse/cbor-parser bytes)
@@ -318,7 +318,7 @@
   If non-laziness is needed, see parse-stream."
   ([reader] (parsed-seq reader nil nil))
   ([reader key-fn] (parsed-seq reader key-fn nil))
-  ([^BufferedReader reader key-fn array-coerce-fn]
+  ([reader key-fn array-coerce-fn]
    (when reader
      (parsed-seq* (parse/json-parser reader)
                   key-fn array-coerce-fn))))
@@ -331,7 +331,7 @@
   and returning the collection to be used for array values."
   ([reader] (parsed-smile-seq reader nil nil))
   ([reader key-fn] (parsed-smile-seq reader key-fn nil))
-  ([^BufferedReader reader key-fn array-coerce-fn]
+  ([reader key-fn array-coerce-fn]
    (when reader
      (parsed-seq* (parse/smile-parser reader)
                   key-fn array-coerce-fn))))

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -10,7 +10,7 @@
            (com.fasterxml.jackson.dataformat.cbor CBORFactory)
            (com.fasterxml.jackson.dataformat.smile SmileFactory)
            (cheshire.prettyprint CustomPrettyPrinter)
-           (java.io StringWriter StringReader BufferedReader BufferedWriter
+           (java.io StringWriter BufferedReader BufferedWriter
                     ByteArrayOutputStream OutputStream Reader Writer)))
 
 (defonce default-pretty-print-options
@@ -206,9 +206,7 @@
   ([^String string key-fn array-coerce-fn]
    (when string
      (parse/parse
-      (.createParser ^JsonFactory (or factory/*json-factory*
-                                      factory/json-factory)
-                     ^Reader (StringReader. string))
+      (parse/json-parser string)
       key-fn nil array-coerce-fn))))
 
 ;; Parsing strictly
@@ -226,9 +224,7 @@
   ([^String string key-fn array-coerce-fn]
    (when string
      (parse/parse-strict
-      (.createParser ^JsonFactory (or factory/*json-factory*
-                                      factory/json-factory)
-                     ^Reader (StringReader. string))
+      (parse/json-parser string)
       key-fn nil array-coerce-fn))))
 
 (defn parse-stream
@@ -250,9 +246,7 @@
   ([^BufferedReader rdr key-fn array-coerce-fn]
    (when rdr
      (parse/parse
-      (.createParser ^JsonFactory (or factory/*json-factory*
-                                      factory/json-factory)
-                     ^Reader rdr)
+      (parse/json-parser rdr)
       key-fn nil array-coerce-fn))))
 
 (defn parse-stream-strict
@@ -270,9 +264,7 @@
   ([^BufferedReader rdr key-fn array-coerce-fn]
    (when rdr
      (parse/parse-strict
-       (.createParser ^JsonFactory (or factory/*json-factory*
-                                       factory/json-factory)
-                      ^Reader rdr)
+       (parse/json-parser rdr)
        key-fn nil array-coerce-fn))))
 
 (defn parse-smile
@@ -287,8 +279,7 @@
   ([^bytes bytes key-fn array-coerce-fn]
    (when bytes
      (parse/parse
-      (.createParser ^SmileFactory (or factory/*smile-factory*
-                                       factory/smile-factory) bytes)
+      (parse/smile-parser bytes)
       key-fn nil array-coerce-fn))))
 
 (defn parse-cbor
@@ -303,8 +294,7 @@
   ([^bytes bytes key-fn array-coerce-fn]
    (when bytes
      (parse/parse
-      (.createParser ^CBORFactory (or factory/*cbor-factory*
-                                      factory/cbor-factory) bytes)
+      (parse/cbor-parser bytes)
       key-fn nil array-coerce-fn))))
 
 (def ^{:doc "Object used to determine end of lazy parsing attempt."}
@@ -330,10 +320,7 @@
   ([reader key-fn] (parsed-seq reader key-fn nil))
   ([^BufferedReader reader key-fn array-coerce-fn]
    (when reader
-     (parsed-seq* (.createParser ^JsonFactory
-                                 (or factory/*json-factory*
-                                     factory/json-factory)
-                                 ^Reader reader)
+     (parsed-seq* (parse/json-parser reader)
                   key-fn array-coerce-fn))))
 
 (defn parsed-smile-seq
@@ -346,10 +333,7 @@
   ([reader key-fn] (parsed-smile-seq reader key-fn nil))
   ([^BufferedReader reader key-fn array-coerce-fn]
    (when reader
-     (parsed-seq* (.createParser ^SmileFactory
-                                 (or factory/*smile-factory*
-                                     factory/smile-factory)
-                                 ^Reader reader)
+     (parsed-seq* (parse/smile-parser reader)
                   key-fn array-coerce-fn))))
 
 ;; aliases for clojure-json users

--- a/src/cheshire/parse.clj
+++ b/src/cheshire/parse.clj
@@ -1,5 +1,45 @@
 (ns cheshire.parse
-  (:import (com.fasterxml.jackson.core JsonParser JsonToken)))
+  (:require [cheshire.factory :as factory])
+  (:import (java.io Reader)
+           (com.fasterxml.jackson.core JsonFactory JsonParser JsonToken)
+           (com.fasterxml.jackson.dataformat.cbor CBORFactory)
+           (com.fasterxml.jackson.dataformat.smile SmileFactory)))
+
+(defprotocol ToJsonParser
+  (-json-parser [self ^JsonFactory factory]))
+
+(defprotocol ToCBORParser
+  (-cbor-parser [self ^CBORFactory factory]))
+
+(defprotocol ToSmileParser
+  (-smile-parser [self ^SmileFactory factory]))
+
+(extend-protocol ToJsonParser
+  String
+  (-json-parser [self ^JsonFactory factory] (.createParser factory self))
+
+  Reader
+  (-json-parser [self ^JsonFactory factory] (.createParser factory self)))
+
+(extend-protocol ToCBORParser
+  (Class/forName "[B")
+  (-cbor-parser [self ^CBORFactory factory] (.createParser factory self)))
+
+(extend-protocol ToSmileParser
+  (Class/forName "[B")
+  (-smile-parser [self ^SmileFactory factory] (.createParser factory self))
+
+  Reader
+  (-smile-parser [self ^SmileFactory factory] (.createParser factory self)))
+
+(defn json-parser [input]
+  (-json-parser input (or factory/*json-factory* factory/json-factory)))
+
+(defn cbor-parser [input]
+  (-cbor-parser input (or factory/*cbor-factory* factory/cbor-factory)))
+
+(defn smile-parser [input]
+  (-smile-parser input (or factory/*smile-factory* factory/smile-factory)))
 
 (declare parse*)
 


### PR DESCRIPTION
Fixes #98. Incidentally `cheshire.parse/json-parser` et al. added here also make the workaround for #94 less verbose.