### PR TITLE
Bump dependencies (jackson -> 2.12.3)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,9 @@
             :url "http://opensource.org/licenses/MIT"
             :distribution :repo}
   :global-vars {*warn-on-reflection* false}
-  :dependencies [[com.fasterxml.jackson.core/jackson-core "2.12.2"]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.12.2"]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.12.2"]
+  :dependencies [[com.fasterxml.jackson.core/jackson-core "2.12.3"]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.12.3"]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.12.3"]
                  [tigris "0.1.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.3"]
                                   [org.clojure/test.generative "0.1.4"]


### PR DESCRIPTION
Many libraries in the Clojure ecosystem do now use Jasonista.

Both: Jasonista and Cheshire use Jackson but on different versions and with different sub-modules.
The version difference causes often incompatibilities between the two.

This PR bumps the Jackson dependency to the [same version used by Jasonista](https://github.com/metosin/jsonista/blob/master/project.clj#L15-L17) in the attempt to reduce conflict pain.
