### PR TITLE
Add dependency exclusion for jackson-databind.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,10 @@
             :distribution :repo}
   :global-vars {*warn-on-reflection* false}
   :dependencies [[com.fasterxml.jackson.core/jackson-core "2.12.4"]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.12.4"]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.12.4"]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.12.4"
+                  :exclusions [com.fasterxml.jackson.core/jackson-databind]]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.12.4"
+                  :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [tigris "0.1.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.3"]
                                   [org.clojure/test.generative "0.1.4"]


### PR DESCRIPTION
The jackson-databind library is not actually used by Cheshire; as far
as I can tell it's not even possible to use from Clojure.

This library is plagued by a nonstop stream of CVEs:

https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html

After the log4j incident, it seems prudent to reconsider the inclusion
of dependencies that have a lot of "magic" features that aren't
actually used.