### PR TITLE
readme: add babashka built-in badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ encoding and SMILE support.
 
 [![Clojars Project](https://img.shields.io/clojars/v/cheshire.svg)](https://clojars.org/cheshire)
 [![Continuous Integration status](https://secure.travis-ci.org/dakrone/cheshire.png)](http://travis-ci.org/dakrone/cheshire)
+[![bb built-in](https://raw.githubusercontent.com/babashka/babashka/master/logo/built-in-badge.svg)](https://babashka.org)
 
 ## Why?
 


### PR DESCRIPTION
Cheshire is built directly into babashka, we can let folks know that at-a-glance with the bb built-in badge!