### PR TITLE
Attempt an initial migration to test.generative 1.0.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [tigris "0.1.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.11.1"]
-                                  [org.clojure/test.generative "0.1.4"]
+                                  [org.clojure/test.generative "1.0.0"]
                                   [org.clojure/tools.namespace "0.3.1"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}


### PR DESCRIPTION
I'm not at all sure this is right, since I don't know test.generative or data.generators well, but it at least allows `lein test :generative` to work again with 1.0.0.
