### PR TITLE
Add example to create JSON string without escaped characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ encoders.
 ;; generate JSON and munge keys with a custom function
 (generate-string {:foo "bar"} {:key-fn (fn [k] (.toUpperCase (name k)))})
 ;; => "{\"FOO\":\"bar\"}"
+
+;; generate JSON without escaping the characters (by writing it to a file)
+(spit "foo.json" (json/generate-string {:foo "bar"} {:pretty true}))
 ```
 
 In the event encoding fails, Cheshire will throw a `JsonGenerationException`.


### PR DESCRIPTION
Kind of obvious but it did not occur to me at first and I struggled with this for a second (_“How do I make it print to console without escaping the characters?!”_)