### PR TITLE
Allow parser customizations via protocol

### DIFF
--- a/src/cheshire/exact.clj
+++ b/src/cheshire/exact.clj
@@ -24,8 +24,12 @@
    (when string
      (let [jp (.createParser ^JsonFactory (or factory/*json-factory*
                                               factory/json-factory)
-                             ^Reader (StringReader. string))]
-       (exact-parse jp (parse/parse jp key-fn nil array-coerce-fn))))))
+                             ^Reader (StringReader. string))
+           parsed (parse/parse (or core/*parser*
+                                   (parse/backwards-compatible-parser key-fn array-coerce-fn))
+                               jp
+                               nil)]
+       (exact-parse jp parsed)))))
 
 (defn parse-string-strict
   ([string] (parse-string-strict string nil nil))
@@ -34,8 +38,12 @@
    (when string
      (let [jp (.createParser ^JsonFactory (or factory/*json-factory*
                                               factory/json-factory)
-                             ^Writer (StringReader. string))]
-       (exact-parse jp (parse/parse-strict jp key-fn nil array-coerce-fn))))))
+                             ^Writer (StringReader. string))
+           parsed (parse/parse-strict (or core/*parser*
+                                          (parse/backwards-compatible-parser key-fn array-coerce-fn))
+                                      jp
+                                      nil)]
+       (exact-parse jp parsed)))))
 
 (def decode parse-string)
 (core/copy-arglists decode parse-string)

--- a/src/cheshire/parse.clj
+++ b/src/cheshire/parse.clj
@@ -1,20 +1,31 @@
 (ns cheshire.parse
   (:import (com.fasterxml.jackson.core JsonParser JsonToken)))
 
+(defprotocol IParser
+  :extend-via-metadata true
+  (parse-object [this jp])
+  (parse-object-key [this jp key-str])
+  (parse-array [this jp])
+  (parse-string [this jp])
+  (parse-number-int [this jp])
+  (parse-number-float [this jp])
+  (parse-embedded-object [this jp]))
+
 (declare parse*)
 
 (def ^:dynamic *chunk-size* 32)
 
 (def ^{:doc "Flag to determine whether float values should be returned as
              BigDecimals to retain precision. Defaults to false."
-       :dynamic true}
+       :dynamic true
+       :deprecated true}
   *use-bigdecimals?* false)
 
 (defmacro ^:private tag
   ([obj]
      `(vary-meta ~obj assoc :tag `JsonParser)))
 
-(definline parse-object [^JsonParser jp key-fn bd? array-coerce-fn]
+(definline default-parse-object [p ^JsonParser jp]
   (let [jp (tag jp)]
     `(do
        (.nextToken ~jp)
@@ -23,78 +34,192 @@
                              JsonToken/END_OBJECT)
            (let [key-str# (.getText ~jp)
                  _# (.nextToken ~jp)
-                 key# (~key-fn key-str#)
+                 key# (parse-object-key ~p ~jp key-str#)
                  mmap# (assoc! mmap# key#
-                               (parse* ~jp ~key-fn ~bd? ~array-coerce-fn))]
+                               (parse* ~p ~jp))]
              (.nextToken ~jp)
              (recur mmap#))
            (persistent! mmap#))))))
 
-(definline parse-array [^JsonParser jp key-fn bd? array-coerce-fn]
+(definline default-parse-array [p ^JsonParser jp seed]
   (let [jp (tag jp)]
-    `(let [array-field-name# (.getCurrentName ~jp)]
+    `(do
        (.nextToken ~jp)
-       (loop [coll# (transient (if ~array-coerce-fn
-                                 (~array-coerce-fn array-field-name#)
-                                 []))]
+       (loop [coll# (transient ~seed)]
          (if-not (identical? (.getCurrentToken ~jp)
                              JsonToken/END_ARRAY)
            (let [coll# (conj! coll#
-                              (parse* ~jp ~key-fn ~bd? ~array-coerce-fn))]
+                              (parse* ~p ~jp))]
              (.nextToken ~jp)
              (recur coll#))
            (persistent! coll#))))))
 
-(defn lazily-parse-array [^JsonParser jp key-fn bd? array-coerce-fn]
+(defn lazily-parse-array [p ^JsonParser jp]
   (lazy-seq
    (loop [chunk-idx 0, buf (chunk-buffer *chunk-size*)]
      (if (identical? (.getCurrentToken jp) JsonToken/END_ARRAY)
        (chunk-cons (chunk buf) nil)
        (do
-         (chunk-append buf (parse* jp key-fn bd? array-coerce-fn))
+         (chunk-append buf (parse* p jp))
          (.nextToken jp)
          (let [chunk-idx* (unchecked-inc chunk-idx)]
            (if (< chunk-idx* *chunk-size*)
              (recur chunk-idx* buf)
              (chunk-cons
               (chunk buf)
-              (lazily-parse-array jp key-fn bd? array-coerce-fn)))))))))
+              (lazily-parse-array p jp)))))))))
 
-(defn parse* [^JsonParser jp key-fn bd? array-coerce-fn]
+(defn default-parse-string [p ^JsonParser jp]
+  (.getText jp))
+
+(defn default-parse-number-int [p ^JsonParser jp]
+  (.getNumberValue jp))
+
+(defn default-parse-number-float [p ^JsonParser jp]
+  (.getNumberValue jp))
+
+(defn default-parse-embedded-object [p ^JsonParser jp]
+  (.getBinaryValue jp))
+
+(defn default-parse-object-key [p jp key-str]
+  key-str)
+
+(defn make-parser [{::syms [parse-object
+                            parse-object-key
+                            parse-array
+                            parse-string
+                            parse-number-int
+                            parse-number-float
+                            parse-embedded-object]
+                    :or    {parse-object          default-parse-object
+                            parse-object-key      default-parse-object-key
+                            parse-array           default-parse-array
+                            parse-string          default-parse-string
+                            parse-number-int      default-parse-number-int
+                            parse-number-float    default-parse-number-float
+                            parse-embedded-object default-parse-embedded-object}}]
+  (cond (and (identical? parse-object default-parse-object)
+             (identical? parse-array default-parse-array))
+        (reify IParser
+          (parse-object [this jp]
+            (default-parse-object this jp))
+          (parse-object-key [this jp key-str]
+            (parse-object-key this jp key-str))
+          (parse-array [this jp]
+            (default-parse-array this jp []))
+          (parse-string [this jp]
+            (parse-string this jp))
+          (parse-number-int [this jp]
+            (parse-number-int this jp))
+          (parse-number-float [this jp]
+            (parse-number-float this jp))
+          (parse-embedded-object [this jp]
+            (parse-embedded-object this jp)))
+
+        (identical? parse-object default-parse-object)
+        (reify IParser
+          (parse-object [this jp]
+            (default-parse-object this jp))
+          (parse-object-key [this jp key-str]
+            (parse-object-key this jp key-str))
+          (parse-array [this jp]
+            (parse-array this jp))
+          (parse-string [this jp]
+            (parse-string this jp))
+          (parse-number-int [this jp]
+            (parse-number-int this jp))
+          (parse-number-float [this jp]
+            (parse-number-float this jp))
+          (parse-embedded-object [this jp]
+            (parse-embedded-object this jp)))
+
+        :else
+        (reify IParser
+          (parse-object [this jp]
+            (parse-object this jp))
+          (parse-object-key [this jp key-str]
+            (parse-object-key this jp key-str))
+          (parse-array [this jp]
+            (parse-array this jp))
+          (parse-string [this jp]
+            (parse-string this jp))
+          (parse-number-int [this jp]
+            (parse-number-int this jp))
+          (parse-number-float [this jp]
+            (parse-number-float this jp))
+          (parse-embedded-object [this jp]
+            (parse-embedded-object this jp)))))
+
+(def default-parser
+  (make-parser {}))
+
+(defn parse-number-decimal [p ^JsonParser jp]
+  (.getDecimalValue ^JsonParser jp))
+
+(defn parse-object-key-with-key-fn [key-fn]
+  (let [key-fn (if (boolean? key-fn)
+                 keyword
+                 key-fn)]
+    (fn [_ _ key-str]
+      (key-fn key-str))))
+
+(defn parse-array-with-coerce-fn [array-coerce-fn]
+  (fn [p ^JsonParser jp]
+    (let [array-field-name (.getCurrentName jp)]
+      (default-parse-array p jp (array-coerce-fn array-field-name)))))
+
+(defn backwards-compatible-parser
+  ([key-fn]
+   (backwards-compatible-parser key-fn nil))
+  ([key-fn array-coerce-fn]
+   (backwards-compatible-parser key-fn array-coerce-fn *use-bigdecimals?*))
+  ([key-fn array-coerce-fn use-big-decimals?]
+   (if (or key-fn array-coerce-fn use-big-decimals?)
+     (cond-> {}
+       key-fn
+       (assoc `parse-object-key (parse-object-key-with-key-fn key-fn))
+
+       (some? array-coerce-fn)
+       (assoc `parse-array (parse-array-with-coerce-fn array-coerce-fn))
+
+       use-big-decimals?
+       (assoc `parse-number-float parse-number-decimal)
+
+       :always
+       (make-parser))
+     default-parser)))
+
+(defn parse* [p ^JsonParser jp]
   (condp identical? (.getCurrentToken jp)
-    JsonToken/START_OBJECT (parse-object jp key-fn bd? array-coerce-fn)
-    JsonToken/START_ARRAY (parse-array jp key-fn bd? array-coerce-fn)
-    JsonToken/VALUE_STRING (.getText jp)
-    JsonToken/VALUE_NUMBER_INT (.getNumberValue jp)
-    JsonToken/VALUE_NUMBER_FLOAT (if bd?
-                                   (.getDecimalValue jp)
-                                   (.getNumberValue jp))
-    JsonToken/VALUE_EMBEDDED_OBJECT (.getBinaryValue jp)
-    JsonToken/VALUE_TRUE true
-    JsonToken/VALUE_FALSE false
-    JsonToken/VALUE_NULL nil
+    JsonToken/START_OBJECT          (parse-object p jp)
+    JsonToken/START_ARRAY           (parse-array p jp)
+    JsonToken/VALUE_STRING          (parse-string p jp)
+    JsonToken/VALUE_NUMBER_INT      (parse-number-int p jp)
+    JsonToken/VALUE_NUMBER_FLOAT    (parse-number-float p jp)
+    JsonToken/VALUE_EMBEDDED_OBJECT (parse-embedded-object p jp)
+    JsonToken/VALUE_TRUE            true
+    JsonToken/VALUE_FALSE           false
+    JsonToken/VALUE_NULL            nil
     (throw
      (Exception.
       (str "Cannot parse " (pr-str (.getCurrentToken jp)))))))
 
-(defn parse-strict [^JsonParser jp key-fn eof array-coerce-fn]
-  (let [key-fn (or (if (identical? key-fn true) keyword key-fn) identity)]
-    (.nextToken jp)
-    (condp identical? (.getCurrentToken jp)
-      nil
-      eof
-      (parse* jp key-fn *use-bigdecimals?* array-coerce-fn))))
+(defn parse-strict [p ^JsonParser jp eof]
+  (.nextToken jp)
+  (condp identical? (.getCurrentToken jp)
+    nil
+    eof
+    (parse* p jp)))
 
-(defn parse [^JsonParser jp key-fn eof array-coerce-fn]
-  (let [key-fn (or (if (and (instance? Boolean key-fn) key-fn) keyword key-fn) identity)]
-    (.nextToken jp)
-    (condp identical? (.getCurrentToken jp)
-      nil
-      eof
+(defn parse [p ^JsonParser jp eof]
+  (.nextToken jp)
+  (condp identical? (.getCurrentToken jp)
+    nil
+    eof
 
-      JsonToken/START_ARRAY
-      (do
-        (.nextToken jp)
-        (lazily-parse-array jp key-fn *use-bigdecimals?* array-coerce-fn))
+    JsonToken/START_ARRAY
+    (do
+      (.nextToken jp)
+      (lazily-parse-array p jp))
 
-      (parse* jp key-fn *use-bigdecimals?* array-coerce-fn))))
+    (parse* p jp)))


### PR DESCRIPTION
Had some slack time on a train ride and decided to give a patch for addressing #105 a shot.

This patch introduces the `IParser` protocol for customizing how values are parsed (except for booleans and null). It subsumes the already existing customization options `key-fn`, `array-coerce-fn` and `*use-bigdecimals?*` (see `backwards-compatible-parser`). For maximal performance, users should reify a parser once and share it across parser invocations. The default parser is shared by default.

Benchmarks show negligible overhead. To that end, care was taken that the existing inlineable parsers continue to be inlined when possible. Attached are the outputs of `lein benchmark` [before](https://github.com/dakrone/cheshire/files/13562842/before.log) and [after](https://github.com/dakrone/cheshire/files/13562847/after.log) the patch. For quick comparison, here's the mean execution times:

```
$ grep "time mean" before.log 
             Execution time mean : 3.440524 µs
             Execution time mean : 3.871193 µs
             Execution time mean : 43.129164 ms
             Execution time mean : 53.539673 ms
             Execution time mean : 48.274296 ms
             Execution time mean : 5.147940 µs
             Execution time mean : 161.727261 µs
             Execution time mean : 3.290368 µs
             Execution time mean : 3.334065 µs
             Execution time mean : 3.893235 µs
             Execution time mean : 3.682155 µs
             Execution time mean : 3.651921 µs
             Execution time mean : 17.229988 µs
             Execution time mean : 7.796235 µs
             Execution time mean : 8.637538 µs
$ grep "time mean" after.log  
             Execution time mean : 3.504573 µs
             Execution time mean : 3.956286 µs
             Execution time mean : 45.442353 ms
             Execution time mean : 54.671934 ms
             Execution time mean : 48.068894 ms
             Execution time mean : 5.195300 µs
             Execution time mean : 156.385378 µs
             Execution time mean : 3.484085 µs
             Execution time mean : 3.504414 µs
             Execution time mean : 3.880752 µs
             Execution time mean : 3.771605 µs
             Execution time mean : 3.629007 µs
             Execution time mean : 18.077329 µs
             Execution time mean : 7.865809 µs
             Execution time mean : 8.582887 µs
```

A first test serving as an example based on the usecase from #105 is included. I stopped there as a PoC to save effort in case this patch is not accepted. Otherwise, I'm happy to add more tests, some clarifying code comments and a corresponding documentation section.