### PR TITLE
Make JSON parsing more lazy

### DIFF
--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -156,6 +156,16 @@
       {"foo" "bar"} json/parse-stream "{\"foo\":\"bar\"}\n"
       {"foo" "bar"} json/parse-stream-strict "{\"foo\":\"bar\"}\n")
 
+    ;; Lazy parsing should be fully lazy - so e.g. incomplete json should be parsed up until
+    ;; we know the json is incomplete.
+    (let [first-parsed-object (fn [parse]
+                                (with-open [rdr (StringReader. "[{\"foo\": \"bar\"}")]
+                                  (first
+                                    (binding [parse/*chunk-size* 1]
+                                      (parse rdr true)))))]
+      (is (= {:foo "bar"} (first-parsed-object json/parse-stream)))
+      (is (thrown? Exception (first-parsed-object json/parse-stream-strict))))
+
     (are [parsed parse parsee] (= parsed
                                   (with-open [rdr (StringReader. parsee)]
                                     (parse rdr true)))


### PR DESCRIPTION
This patch does 2 things:
 * Fixes the ability to set `*chunk-size*` for lazy streams (the binding can now be set around the `json/parse-stream` call rather than around whatever seq-consumption code you were using).
 * "Fixes" the ability to have a _very_ lazy JSON array-stream that only produces one "message" at a time.

For context on the latter, I have a (weird) protocol that looks like this:
```json
[
{"type": "handshake", "id": 0},
{"type": "command", "id": 1},
...
]
```

The issue is the producer of this JSON is fully lazy - i.e. it outputs one `, {"type": "blah"}` command at a time and "waits" for a response. Cheshire can _almost_ parse this, and with this change it can fully parse this (assuming you set `*chunk-size*` to 1). The root cause is just an issue with calling `nextToken` before returning the element in the sequence (those two should be reversed).