### PR TITLE
tests: remove duplicate test-round-trip-binary

### DIFF
--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -112,15 +112,6 @@
 (def bin-obj {"byte-array" (byte-array (map byte [1 2 3]))})
 
 (deftest test-round-trip-binary
-  (for [[p g] {json/parse-string json/generate-string
-               json/parse-smile  json/generate-smile
-               json/parse-cbor   json/generate-cbor}]
-    (is (let [roundtripped (p (g bin-obj))]
-          ;; test value equality
-          (= (->> bin-obj (get "byte-array") seq)
-             (->> roundtripped (get "byte-array") seq))))))
-
-(deftest test-round-trip-binary
   (doseq [[p g] {json/parse-string json/generate-string
                  json/parse-smile  json/generate-smile
                  json/parse-cbor   json/generate-cbor}]


### PR DESCRIPTION
As part of #213 I noticed `test-round-trip-binary` had no assertions and was using `for`. I meant to fix this in a separate PR but accidentally left my fix in #213 along with the old version of `test-round-trip-binary`.

This change deletes the old `test-round-trip-binary` and leaves in the working one.