### PR TITLE
Expose new Jackson limits via factory options

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,8 @@
 ## Changes between Cheshire 5.13.0 and 5.13.1
 
 * Bump minimum JDK version from v7 to v8
+* Bump Jackson dependencies to 2.18.3
+* Expose new Jackson processing limits via factories
 * Internal maintenance: migrate away from usages of deprecated Jackson 
 
 ## Changes between Cheshire 5.8.1 and 5.9.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 * Bump minimum JDK version from v7 to v8
 * Bump Jackson dependencies to 2.18.3
-* Expose new Jackson processing limits via factories
+* Expose new Jackson processing limits via factory options
 * Internal maintenance: migrate away from usages of deprecated Jackson 
 
 ## Changes between Cheshire 5.8.1 and 5.9.0

--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,10 @@
             :url "http://opensource.org/licenses/MIT"
             :distribution :repo}
   :global-vars {*warn-on-reflection* false}
-  :dependencies [[com.fasterxml.jackson.core/jackson-core "2.17.0"]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.17.0"
+  :dependencies [[com.fasterxml.jackson.core/jackson-core "2.18.3"]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.18.3"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.17.0"
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.18.3"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [tigris "0.1.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.12.0"]

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
             [lein-ancient "1.0.0-RC3"]
             [jonase/eastwood "1.4.3"]]
   :java-source-paths ["src/java"]
-  :jvm-opts ["-Xmx512M"
+  :jvm-opts ["-Xmx1024M"
 ;;             "-XX:+PrintCompilation"
 ;;             "-XX:+UnlockDiagnosticVMOptions"
 ;;             "-XX:+PrintInlining"

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -5,8 +5,7 @@
             [cheshire.exact :as json-exact]
             [cheshire.generate :as gen]
             [cheshire.factory :as fact]
-            [cheshire.parse :as parse]
-            [clojure.string :as str])
+            [cheshire.parse :as parse])
   (:import (com.fasterxml.jackson.core JsonGenerationException
                                        JsonParseException)
            (com.fasterxml.jackson.core.exc StreamConstraintsException)
@@ -524,7 +523,7 @@
   (let [edn (nested-map 100)]
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-output-nesting-depth 100})]
-      (is (str/includes? (json/encode edn) "\"99\"")))
+      (is (.contains (json/encode edn) "\"99\"")))
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-output-nesting-depth 99})]
       (is (thrown-with-msg?

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -410,7 +410,9 @@
     (binding [fact/*json-factory* (fact/make-json-factory
                                     ;; as per Jackson docs, limit is inexact, so dividing input length by 2 should do the trick
                                     {:max-input-document-length (/ (count sample-data) 2)})]
-      (is (thrown? JsonProcessingException (json/decode sample-data))))))
+      (is (thrown-with-msg?
+            JsonProcessingException #"(?i)document length .* exceeds"
+            (json/decode sample-data))))))
 
 (deftest t-bindable-factories-max-input-token-count
   ;; A token is a single unit of input, such as a number, a string, an object start or end, or an array start or end.
@@ -421,7 +423,9 @@
       (is (= edn (json/decode sample-data))))
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-input-token-count 5})]
-      (is (thrown? JsonProcessingException (json/decode sample-data))))))
+      (is (thrown-with-msg?
+            JsonProcessingException #"(?i)token count .* exceeds"
+            (json/decode sample-data))))))
 
 (deftest t-bindable-factories-max-input-name-length
   (let [k "somekey"
@@ -432,7 +436,9 @@
       (is (= edn (json/decode sample-data))))
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-input-name-length (dec (count k))})]
-      (is (thrown? JsonProcessingException (json/decode sample-data))))))
+      (is (thrown-with-msg?
+            JsonProcessingException #"(?i)name .* exceeds"
+            (json/decode sample-data))))))
 
 (defn- nested-map [depth]
   (reduce (fn [acc n] {(str n) acc})
@@ -447,7 +453,9 @@
       (is (= edn (json/decode sample-data))))
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-input-nesting-depth 99})]
-      (is (thrown? JsonProcessingException (json/decode sample-data))))))
+      (is (thrown-with-msg?
+            JsonProcessingException #"(?i)nesting depth .* exceeds"
+            (json/decode sample-data))))))
 
 (deftest t-bindable-factories-max-input-number-length
   (let [num 123456789
@@ -458,7 +466,9 @@
       (is (= edn (json/decode sample-data))))
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-input-number-length (-> num str count dec)})]
-      (is (thrown? JsonProcessingException (json/decode sample-data))))))
+      (is (thrown-with-msg?
+            JsonProcessingException #"(?i)number value length .* exceeds"
+            (json/decode sample-data))))))
 
 (deftest t-bindable-factories-max-input-string-length
   (let [big-string (apply str (repeat 40000000 "x"))
@@ -469,7 +479,9 @@
       (is (= edn (json/decode sample-data))))
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-input-string-length (dec (count big-string))})]
-      (is (thrown? JsonProcessingException (json/decode sample-data))))))
+      (is (thrown-with-msg?
+            JsonProcessingException #"(?i)string value length .* exceeds"
+            (json/decode sample-data))))))
 
 (deftest t-bindable-factories-max-output-nesting-depth
   (let [edn (nested-map 100)]
@@ -478,7 +490,9 @@
       (is (= (json/encode edn) (json/encode edn))))
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-output-nesting-depth 99})]
-      (is (thrown? JsonProcessingException (json/encode edn))))))
+      (is (thrown-with-msg?
+            JsonProcessingException #"(?i)nesting depth .* exceeds"
+            (json/encode edn))))))
 
 (deftest t-persistent-queue
   (let [q (conj (clojure.lang.PersistentQueue/EMPTY) 1 2 3)]

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -7,8 +7,8 @@
             [cheshire.factory :as fact]
             [cheshire.parse :as parse])
   (:import (com.fasterxml.jackson.core JsonGenerationException
-                                       JsonParseException
-                                       JsonProcessingException)
+                                       JsonParseException)
+           (com.fasterxml.jackson.core.exc StreamConstraintsException)
            (java.io FileInputStream StringReader StringWriter
                     BufferedReader BufferedWriter
                     IOException)
@@ -411,7 +411,7 @@
                                     ;; as per Jackson docs, limit is inexact, so dividing input length by 2 should do the trick
                                     {:max-input-document-length (/ (count sample-data) 2)})]
       (is (thrown-with-msg?
-            JsonProcessingException #"(?i)document length .* exceeds"
+            StreamConstraintsException #"(?i)document length .* exceeds"
             (json/decode sample-data))))))
 
 (deftest t-bindable-factories-max-input-token-count
@@ -424,7 +424,7 @@
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-input-token-count 5})]
       (is (thrown-with-msg?
-            JsonProcessingException #"(?i)token count .* exceeds"
+            StreamConstraintsException #"(?i)token count .* exceeds"
             (json/decode sample-data))))))
 
 (deftest t-bindable-factories-max-input-name-length
@@ -437,7 +437,7 @@
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-input-name-length (dec (count k))})]
       (is (thrown-with-msg?
-            JsonProcessingException #"(?i)name .* exceeds"
+            StreamConstraintsException #"(?i)name .* exceeds"
             (json/decode sample-data))))))
 
 (defn- nested-map [depth]
@@ -454,7 +454,7 @@
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-input-nesting-depth 99})]
       (is (thrown-with-msg?
-            JsonProcessingException #"(?i)nesting depth .* exceeds"
+            StreamConstraintsException #"(?i)nesting depth .* exceeds"
             (json/decode sample-data))))))
 
 (deftest t-bindable-factories-max-input-number-length
@@ -467,7 +467,7 @@
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-input-number-length (-> num str count dec)})]
       (is (thrown-with-msg?
-            JsonProcessingException #"(?i)number value length .* exceeds"
+            StreamConstraintsException #"(?i)number value length .* exceeds"
             (json/decode sample-data))))))
 
 (deftest t-bindable-factories-max-input-string-length
@@ -480,7 +480,7 @@
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-input-string-length (dec (count big-string))})]
       (is (thrown-with-msg?
-            JsonProcessingException #"(?i)string value length .* exceeds"
+            StreamConstraintsException #"(?i)string value length .* exceeds"
             (json/decode sample-data))))))
 
 (deftest t-bindable-factories-max-output-nesting-depth
@@ -491,7 +491,7 @@
     (binding [fact/*json-factory* (fact/make-json-factory
                                     {:max-output-nesting-depth 99})]
       (is (thrown-with-msg?
-            JsonProcessingException #"(?i)nesting depth .* exceeds"
+            StreamConstraintsException #"(?i)nesting depth .* exceeds"
             (json/encode edn))))))
 
 (deftest t-persistent-queue


### PR DESCRIPTION
Note to reviewer(s):
1. Bumped to Jackson 2.18.3 (current version) to pick up another new Jackson limit: max token count
2. On blown limits Jackson throws a `StreamConstraintsException`, I think formerly cheshire users were limited to looking for `JsonParseException` and `JsonGeneratinException`, or maybe they just looked for the generic `JsonProcessingException`?. Relevant Jackson class hierarchy:
    ```
    - java.lang.Exception
      - java.io.IOException
        - JacksonException
          - JsonProcessingException
            - StreamConstraintsException (thrown when a limit is blown)
            - StreamReadException
              - JsonParseException
            - StreamWriteException
              - JsonGenerationException
    ```
3. Hardcoded cheshire default limits to current Jackson limits. This means if Jackson default limits change in some future release, cheshire will not automatically pick them up. This seems to match the strategy for other factory opts.
4. Tested default limits where I could but cheshire seems to suffer a StackOverflow for very deeply nested structures. Will raise a separate issue for this.

Closes #210. 