### PR TITLE
Add `:escape-non-ascii` to factory options

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 * Bump minimum JDK version from v7 to v8
 * Bump Jackson dependencies to 2.18.3
 * Expose new Jackson processing limits via factory options
+* Add `:escape-non-ascii` to factory options
 * Internal maintenance: migrate away from usages of deprecated Jackson 
 
 ## Changes between Cheshire 5.8.1 and 5.9.0

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -69,8 +69,10 @@
          PrettyPrinter
            (.setPrettyPrinter generator print-pretty)
          nil))
-     (when (:escape-non-ascii opt-map)
-       (.enable generator (.mappedFeature JsonWriteFeature/ESCAPE_NON_ASCII)))
+     ;; legacy fn opt, consider using fatory opt instead
+     (when (some? (:escape-non-ascii opt-map))
+       (.configure generator (.mappedFeature JsonWriteFeature/ESCAPE_NON_ASCII)
+                   (boolean (:escape-non-ascii opt-map))))
      (gen/generate generator obj
                    (or (:date-format opt-map) factory/default-date-format)
                    (:ex opt-map)
@@ -101,8 +103,10 @@
          PrettyPrinter
        (.setPrettyPrinter generator print-pretty)
          nil))
-     (when (:escape-non-ascii opt-map)
-       (.enable generator (.mappedFeature JsonWriteFeature/ESCAPE_NON_ASCII)))
+     ;; legacy fn opt, consider using fatory opt instead
+     (when (some? (:escape-non-ascii opt-map))
+       (.configure generator (.mappedFeature JsonWriteFeature/ESCAPE_NON_ASCII)
+                   (boolean (:escape-non-ascii opt-map))))
      (gen/generate generator obj (or (:date-format opt-map)
                                      factory/default-date-format)
                    (:ex opt-map)

--- a/src/cheshire/custom.clj
+++ b/src/cheshire/custom.clj
@@ -35,8 +35,9 @@
                         ^JsonFactory (or *json-factory* json-factory) sw)]
          (when (:pretty opt-map)
            (.useDefaultPrettyPrinter generator))
-         (when (:escape-non-ascii opt-map)
-           (.enable generator (.mappedFeature JsonWriteFeature/ESCAPE_NON_ASCII)))
+         (when (some? (:escape-non-ascii opt-map))
+           (.configure generator (.mappedFeature JsonWriteFeature/ESCAPE_NON_ASCII)
+                       (boolean (:escape-non-ascii opt-map))))
          (if obj
            (to-json obj generator)
            (.writeNull generator))
@@ -55,11 +56,14 @@
                         ^JsonFactory (or *json-factory* json-factory) w)]
          (when (:pretty opt-map)
            (.useDefaultPrettyPrinter generator))
-         (when (:escape-non-ascii opt-map)
-           (.enable generator (.mappedFeature JsonWriteFeature/ESCAPE_NON_ASCII)))
+         (when (some? (:escape-non-ascii opt-map))
+           (.configure generator (.mappedFeature JsonWriteFeature/ESCAPE_NON_ASCII)
+                       (boolean (:escape-non-ascii opt-map))))
          (to-json obj generator)
          (.flush generator)
          w))))
+
+
 
 (def encode-stream encode-stream*)
 (core/copy-arglists encode-stream encode-stream*)

--- a/src/cheshire/factory.clj
+++ b/src/cheshire/factory.clj
@@ -23,6 +23,7 @@
    :allow-non-numeric-numbers false
    :intern-field-names false
    :canonicalize-field-names false
+   :escape-non-ascii false
    :quote-field-names true
    :strict-duplicate-detection false
    ;; default values from Jackson 2.18.3
@@ -74,7 +75,9 @@
       (.configure JsonReadFeature/ALLOW_NON_NUMERIC_NUMBERS
                   (boolean (:allow-non-numeric-numbers opts)))
       (.configure JsonWriteFeature/QUOTE_FIELD_NAMES
-                  (boolean (:quote-field-names opts)))))
+                  (boolean (:quote-field-names opts)))
+      (.configure JsonWriteFeature/ESCAPE_NON_ASCII
+                  (boolean (:escape-non-ascii opts)))))
 
 ;; Factory objects that are needed to do the encoding and decoding
 (defn make-json-factory


### PR DESCRIPTION
Cheshire options are configured through factory options.

Fn options are considered legacy and a historical artifact.

`escape-non-ascii` was only specifiable via a fn opt. Allow it to be specified as a factory option while continuing to recognize it as a fn option.

Closes #215