### PR TITLE
windows only: pretty printing `:line-break` now always defaults to OS default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,11 @@ jobs:
         os: [ ubuntu, windows ]
         java-version: [ '8', '11', '17', '21', '23' ]
 
+    defaults:
+      run:
+        # Windows lein.ps1 script is problematic, force lein.bat by using cmd shell
+        shell: ${{ matrix.os == 'windows' && 'cmd' || 'bash' }}
+
     name: test ${{matrix.os}} jdk${{matrix.java-version}}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
       with:
         path: |
           ~/.m2/repository
-        key: $${ runner.os }}-cljdeps-${{ hashFiles('project.clj') }}
-        restore-keys: $${ runner.os }}-cljdeps-
+        key: ${{ runner.os }}-cljdeps-${{ hashFiles('project.clj') }}
+        restore-keys: ${{ runner.os }}-cljdeps-
 
     - name: Setup Java
       uses: actions/setup-java@v4
@@ -70,8 +70,8 @@ jobs:
       with:
         path: |
           ~/.m2/repository
-        key: $${ runner.os }}-cljdeps-${{ hashFiles('project.clj') }}
-        restore-keys: $${ runner.os }}-cljdeps-
+        key: ${{ runner.os }}-cljdeps-${{ hashFiles('project.clj') }}
+        restore-keys: ${{ runner.os }}-cljdeps-
 
     - name: Setup Java
       uses: actions/setup-java@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu ]
+        os: [ ubuntu, windows ]
         java-version: [ '8', '11', '17', '21', '23' ]
 
     name: test ${{matrix.os}} jdk${{matrix.java-version}}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-## Changes between Cheshire 5.13.0 and 5.14.0
+## Changes between Cheshire 5.13.0 and 6.0.0
 
 * Breaking Fix
   * Windows only: pretty printing now consistently uses JVM's OS default of `\r\n` for `:line-break` [#217](https://github.com/dakrone/cheshire/issues/217)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
-## Changes between Cheshire 5.13.0 and 5.13.1
+## Changes between Cheshire 5.13.0 and 5.14.0
 
+* Breaking Fix
+  * Windows only: pretty printing now consistently uses JVM's OS default of `\r\n` for `:line-break` [#217](https://github.com/dakrone/cheshire/issues/217)
 * Bump minimum JDK version from v7 to v8
 * Bump Jackson dependencies to 2.18.3
 * Expose new Jackson processing limits via factory options

--- a/src/cheshire/core.clj
+++ b/src/cheshire/core.clj
@@ -15,7 +15,7 @@
 
 (defonce default-pretty-print-options
   {:indentation "  "
-   :line-break "\n"
+   :line-break (System/lineSeparator)
    :indent-arrays? false
    :indent-objects? true
    :before-array-values nil

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -1,6 +1,7 @@
 (ns cheshire.test.core
   (:require [clojure.test :refer [deftest testing is are]]
             [clojure.java.io :as io]
+            [clojure.string :as str]
             [cheshire.core :as json]
             [cheshire.exact :as json-exact]
             [cheshire.generate :as gen]
@@ -564,10 +565,26 @@
     (is (= q (json/decode (json/encode q))))))
 
 (deftest t-pretty-print
-  (is (= (str "{\n  \"bar\" : [ {\n    \"baz\" : 2\n  }, "
-              "\"quux\", [ 1, 2, 3 ] ],\n  \"foo\" : 1\n}")
+  (is (= (str/join (System/lineSeparator)
+                   ["{"
+                    "  \"bar\" : [ {"
+                    "    \"baz\" : 2"
+                    "  }, \"quux\", [ 1, 2, 3 ] ],"
+                    "  \"foo\" : 1"
+                    "}"])
          (json/encode (sorted-map :foo 1 :bar [{:baz 2} :quux [1 2 3]])
                       {:pretty true}))))
+
+(deftest t-pretty-print-custom-linebreak
+  (is (= (str/join "foo"
+                   ["{"
+                    "  \"bar\" : [ {"
+                    "    \"baz\" : 2"
+                    "  }, \"quux\", [ 1, 2, 3 ] ],"
+                    "  \"foo\" : 1"
+                    "}"])
+         (json/encode (sorted-map :foo 1 :bar [{:baz 2} :quux [1 2 3]])
+                      {:pretty {:line-break "foo"}}))))
 
 (deftest t-pretty-print-illegal-argument
   ; just expecting this not to throw
@@ -595,17 +612,18 @@
                             :before-array-values ""
                             :after-array-values ""
                             :object-field-value-separator ": "}}
-        expected (str "{\n"
-                      "    \"bar\": {\n"
-                      "        \"baz\": [{\n"
-                      "            \"ulu\": \"mulu\"\n"
-                      "        }, {\n"
-                      "            \"moot\": \"foo\"\n"
-                      "        }, 3]\n"
-                      "    },\n"
-                      "    \"foo\": 1,\n"
-                      "    \"quux\": \"blub\"\n"
-                      "}")
+        expected (str/join (System/lineSeparator)
+                           ["{"
+                            "    \"bar\": {"
+                            "        \"baz\": [{"
+                            "            \"ulu\": \"mulu\""
+                            "        }, {"
+                            "            \"moot\": \"foo\""
+                            "        }, 3]"
+                            "    },"
+                            "    \"foo\": 1,"
+                            "    \"quux\": \"blub\""
+                            "}"])
         pretty-str (json/encode test-obj test-opts)]
 
     ; just to be easy on the eyes in case of error

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -1,7 +1,7 @@
 (ns cheshire.test.core
   (:require [clojure.test :refer [deftest testing is are]]
-            [clojure.java.io :as io])
-  (:require [cheshire.core :as json]
+            [clojure.java.io :as io]
+            [cheshire.core :as json]
             [cheshire.exact :as json-exact]
             [cheshire.generate :as gen]
             [cheshire.factory :as fact]

--- a/test/cheshire/test/custom.clj
+++ b/test/cheshire/test/custom.clj
@@ -2,6 +2,7 @@
   "DEPRECATED, kept here to ensure backward compatibility."
   (:require [clojure.test :refer [deftest is]]
             [clojure.java.io :as io]
+            [clojure.string :as str]
             #_{:clj-kondo/ignore [:deprecated-namespace]}
             [cheshire.custom :as json] :reload
             [cheshire.factory :as fact]
@@ -200,8 +201,13 @@
     (is (= q (json/decode (json/encode* q))))))
 
 (deftest t-pretty-print
-  (is (= (str "{\n  \"bar\" : [ {\n    \"baz\" : 2\n  }, "
-              "\"quux\", [ 1, 2, 3 ] ],\n  \"foo\" : 1\n}")
+  (is (= (str/join (System/lineSeparator)
+                   ["{"
+                    "  \"bar\" : [ {"
+                    "    \"baz\" : 2"
+                    "  }, \"quux\", [ 1, 2, 3 ] ],"
+                    "  \"foo\" : 1"
+                    "}"])
          (json/encode* (sorted-map :foo 1 :bar [{:baz 2} :quux [1 2 3]])
                        {:pretty true}))))
 


### PR DESCRIPTION
Now that Windows tests are passing, this allowed me to add Windows to the CI matrix.

Changelog assumes the next version is 5.14.0 due to the breaking windows bug fix change.

Closes #217

