### PR TITLE
ci: bump jdk 23 to 24 for test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
+        # We also lint with eastwood, using latest jdk release can help find
+        # JDK deprecations
         java-version: 24
 
     - name: Install Clojure Tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 23
+        java-version: 21
 
     - name: Install Clojure Tools
       uses: DeLaGuardo/setup-clojure@13.2
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, windows ]
-        java-version: [ '8', '11', '17', '21', '23' ]
+        java-version: [ '8', '11', '17', '21', '24' ]
 
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 21
+        java-version: 24
 
     - name: Install Clojure Tools
       uses: DeLaGuardo/setup-clojure@13.2


### PR DESCRIPTION
Also, not crazy important, but do ci lint on latest LTS of jdk (instead of latest jdk)