### PR TITLE
vulnerability scan: suppress CVE-2024-22871

### DIFF
--- a/nvd-helper/suppressions.xml
+++ b/nvd-helper/suppressions.xml
@@ -3,4 +3,11 @@
   <!-- This is an automatically generated config file by nvd-clojure. -->
   <!-- Feel free to tweak it, version-control it and remove any comment. -->
   <!-- You can find suppression examples in https://jeremylong.github.io/DependencyCheck/general/suppression.html -->
+  <suppress>
+    <notes><![CDATA[
+    This CVE is described as: An issue in Clojure versions 1.20 to 1.12.0-alpha5 allows an attacker to cause a denial of service (DoS) via the clojure.core$partial$fn__5920 function.
+    False positive; cheshire does not depend on a specific version of Clojure.
+    ]]></notes>
+    <cve>CVE-2024-22871</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
I don't think this one should be popping up, but not applicable anyway because cheshire does not depend on a specific version of Clojure.

Closes #238