### PR TITLE
Encode `java.time.Instant`

### DIFF
--- a/src/cheshire/generate.clj
+++ b/src/cheshire/generate.clj
@@ -4,6 +4,7 @@
            (java.util Date Map List Set SimpleTimeZone UUID)
            (java.sql Timestamp)
            (java.text SimpleDateFormat)
+           (java.time Instant)
            (java.math BigInteger)
            (clojure.lang  Keyword Ratio Symbol)))
 
@@ -151,6 +152,10 @@
    (i? Timestamp obj) (let [sdf (doto (SimpleDateFormat. date-format)
                                   (.setTimeZone (SimpleTimeZone. 0 "UTC")))]
                         (write-string ^JsonGenerator jg (.format sdf obj)))
+   (i? Instant obj) (let [sdf (doto (SimpleDateFormat. date-format)
+                                (.setTimeZone (SimpleTimeZone. 0 "UTC")))
+                          d (Date/from obj)]
+                      (write-string ^JsonGenerator jg (.format sdf d)))
    :else (fail obj jg ex)))
 
 ;; Generic encoders, these can be used by someone writing a custom

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -14,6 +14,7 @@
                     BufferedReader BufferedWriter
                     IOException)
            (java.sql Timestamp)
+           (java.time Instant)
            (java.util Date UUID)))
 
 (defn- str-of-len
@@ -199,6 +200,18 @@
          (json/decode (json/encode {:foo (Timestamp. (long 0))}
                                    {:date-format "yyyy-MM-dd"})))
       "encode with given date format"))
+
+(deftest test-instant
+  (is (= {"foo" "1970-01-01T00:00:00Z"}
+         (json/decode (json/encode {:foo (Instant/ofEpochSecond (long 0))}))))
+  (is (= {"foo" "1970-01-01"}
+         (json/decode (json/encode {:foo (Instant/ofEpochSecond (long 0))}
+                                   {:date-format "yyyy-MM-dd"})))
+      "encode with given date format")
+  (is (= {"foo" "1970-01-01-0004"}
+         (json/decode (json/encode {:foo (Instant/ofEpochSecond (long 0))}
+                                   {:date-format "yyyy-MM-dd-uuuu"})))
+      "use [[java.text.SimpleDateFormat]] format rules"))
 
 (deftest test-uuid
   (let [id (UUID/randomUUID)


### PR DESCRIPTION
Implements #240

`java.time` includes a new [`DateTimeFormatter`](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html) class, that I didn't used to avoid breakage. since the date format of that library handle some date format letter differently than  [`SimpleDateFormat`](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html). For example the **u** letter represent a *year* in the first and *day number of week* in the second