### PR TITLE
Write `java.time.Instant` objects

### DIFF
--- a/src/cheshire/generate_seq.clj
+++ b/src/cheshire/generate_seq.clj
@@ -6,6 +6,7 @@
            (java.util Date Map List Set SimpleTimeZone UUID)
            (java.sql Timestamp)
            (java.text SimpleDateFormat)
+           (java.time Instant)
            (clojure.lang IPersistentCollection Keyword Symbol)))
 
 (definline write-start-object [^JsonGenerator jg wholeness]
@@ -127,4 +128,8 @@
      (g/i? Timestamp obj) (let [sdf (doto (SimpleDateFormat. date-format)
                                       (.setTimeZone (SimpleTimeZone. 0 "UTC")))]
                             (g/write-string ^JsonGenerator jg (.format sdf obj)))
+     (g/i? Instant obj) (let [sdf (doto (SimpleDateFormat. date-format)
+                                    (.setTimeZone (SimpleTimeZone. 0 "UTC")))
+                              d (Date/from obj)]
+                          (g/write-string ^JsonGenerator jg (.format sdf d)))
      :else (g/fail obj jg ex))))

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -211,7 +211,19 @@
   (is (= {"foo" "1970-01-01-0004"}
          (json/decode (json/encode {:foo (Instant/ofEpochSecond (long 0))}
                                    {:date-format "yyyy-MM-dd-uuuu"})))
-      "use [[java.text.SimpleDateFormat]] format rules"))
+      "use [[java.text.SimpleDateFormat]] format rules")
+
+  (is (= {"foo" "1970-01-01T00:00:00Z"}
+         (json/decode
+          (str (json/with-writer [(StringWriter.) nil]
+                 (json/write {:foo (Instant/ofEpochSecond (long 0))}))))))
+
+  (is (= {"foo" "1970-01-01"}
+         (json/decode
+          (str
+           (json/with-writer [(StringWriter.) {:date-format "yyyy-MM-dd"}]
+             (json/write {:foo (Instant/ofEpochSecond (long 0))})))))
+      "write with given date format"))
 
 (deftest test-uuid
   (let [id (UUID/randomUUID)


### PR DESCRIPTION
`write` will handle `java.time.Instant` objects the same way as `encode`