### PR TITLE
Add support for JsonReadFeature ALLOW_TRAILING_COMMA

### DIFF
--- a/src/cheshire/factory.clj
+++ b/src/cheshire/factory.clj
@@ -21,6 +21,7 @@
    :allow-backslash-escaping false
    :allow-numeric-leading-zeros false
    :allow-non-numeric-numbers false
+   :allow-trailing-comma false
    :intern-field-names false
    :canonicalize-field-names false
    :escape-non-ascii false
@@ -74,6 +75,8 @@
                   (boolean (:allow-numeric-leading-zeros opts)))
       (.configure JsonReadFeature/ALLOW_NON_NUMERIC_NUMBERS
                   (boolean (:allow-non-numeric-numbers opts)))
+      (.configure JsonReadFeature/ALLOW_TRAILING_COMMA
+                  (boolean (:allow-trailing-comma opts)))
       (.configure JsonWriteFeature/QUOTE_FIELD_NAMES
                   (boolean (:quote-field-names opts)))
       (.configure JsonWriteFeature/ESCAPE_NON_ASCII

--- a/test/cheshire/test/core.clj
+++ b/test/cheshire/test/core.clj
@@ -427,6 +427,16 @@
                                     {:allow-non-numeric-numbers false})]
       (is (thrown? JsonParseException (json/decode s true))))))
 
+(deftest t-bindable-factories-allow-trailing-comma
+  (let [s "{\"foo\":\"bar\",}"]
+    (binding [fact/*json-factory* (fact/make-json-factory
+                                   {:allow-trailing-comma true})]
+      (is (= "bar"
+             (:foo (json/decode s true)))))
+    (binding [fact/*json-factory* (fact/make-json-factory
+                                   {:allow-trailing-comma false})]
+      (is (thrown? JsonParseException (json/decode s true))))))
+
 (deftest t-bindable-factories-optimization-opts
   (let [s "{\"a\": \"foo\"}"]
     (doseq [opts [{:intern-field-names true}


### PR DESCRIPTION
Just ran into a case where I'm being handed JSON with trailing commas from a 3rd party. It would be nice to be able to cleanly handle this data.

I see that there is an existing PR to add this from 2018 (https://github.com/dakrone/cheshire/pull/137) that's a bit out of date. I went ahead and just made a new branch since the underlying Jackson feature seems to have changed since then.