### PR TITLE
ci: vulnerability scan: disable OSS Index

### DIFF
--- a/.github/workflows/nvd_scan.yml
+++ b/.github/workflows/nvd_scan.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Run NVD Scanner
       env:
         NVD_API_TOKEN: ${{ secrets.NVD_API_TOKEN }}
-      run: clojure -J-Dclojure.main.report=stderr -M -m nvd.task.check "nvd-clojure.edn" "$(cd ..; lein classpath)"
+      run: clojure -J-Dclojure.main.report=stderr -J-Danalyzer.ossindex.enabled=false -M -m nvd.task.check "nvd-clojure.edn" "$(cd ..; lein classpath)"
       working-directory: nvd-helper
 
     - name: Save NVD DB & Clojure Deps Cache


### PR DESCRIPTION
Avoid having to setup credentials for OSS Index by disabling enrichment of findings with OSS Index.

Fixes #247