### PR TITLE
update jackson dependencies to fix GHSA-72hv-8253-57qq

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,10 @@
             :url "http://opensource.org/licenses/MIT"
             :distribution :repo}
   :global-vars {*warn-on-reflection* false}
-  :dependencies [[com.fasterxml.jackson.core/jackson-core "2.20.0"]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.20.0"
+  :dependencies [[com.fasterxml.jackson.core/jackson-core "2.21.1"]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.21.1"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.20.0"
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.21.1"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [tigris "0.1.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.12.2"]


### PR DESCRIPTION
jackson-core 2.20.0 suffers from https://github.com/FasterXML/jackson-core/security/advisories/GHSA-72hv-8253-57qq this PR updates jackson-core, jackson-dataformat-smile and jackson-dataformat-cbor to 2.21.1